### PR TITLE
fix(typescript): Also set the typescript settings to the vue overrides for typescript import resolving

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -14,6 +14,12 @@ vueOverrides.rules = {
 	...typescriptOverrides.rules,
 }
 
+// Add settings, required for import resolver
+vueOverrides.settings = {
+	...(vueOverrides.settings || []),
+	...typescriptOverrides.settings,
+}
+
 // Also extend from vue typescript eslint
 vueOverrides.extends.push('@vue/eslint-config-typescript/recommended')
 


### PR DESCRIPTION
Solving `import/no-unresolved` when using `<script lang="ts">` and importing Typescript files.