### PR TITLE
feat: Add `vue3` sub-configuration to allow linting Vue 3 projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ module.exports = {
 }
 ```
 
+### Usage with Vue 3 projects
+
+If your projects uses Vue 3 you have to use the `vue3` sub-configuration.
+This configuration also includes Typescript support by default.
+
+Add a file `.eslintrc.js` in the root directory of your app repository with the following content:
+
+```js
+module.exports = {
+	extends: [
+		'@nextcloud/eslint-config/vue3',
+	],
+}
+```
+
 ## Release new version
 
  1. Update CHANGELOG.md file with the latest changes

--- a/parts/vue3.js
+++ b/parts/vue3.js
@@ -1,0 +1,39 @@
+module.exports = {
+	files: ['**/*.vue'],
+	parser: 'vue-eslint-parser',
+	parserOptions: {
+		parser: '@babel/eslint-parser',
+	},
+	extends: ['plugin:vue3/recommended'],
+	rules: {
+		'vue/html-indent': ['error', 'tab'],
+		// PascalCase components names for vuejs
+		// https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-templates
+		'vue/component-name-in-template-casing': ['error', 'PascalCase'],
+		// force name
+		'vue/match-component-file-name': ['error', {
+			extensions: ['jsx', 'vue', 'js', 'ts', 'tsx'],
+			shouldMatchCase: true,
+		}],
+		// space before self-closing elements
+		'vue/html-closing-bracket-spacing': 'error',
+		// no ending html tag on a new line
+		'vue/html-closing-bracket-newline': ['error', { multiline: 'never' }],
+		// check vue files too
+		'n/no-missing-import': ['error', {}],
+		// code spacing with attributes
+		'vue/max-attributes-per-line': ['error', {
+			singleline: 3,
+			multiline: 1,
+		}],
+		// See https://vuejs.org/style-guide/rules-strongly-recommended.html#multi-attribute-elements
+		'vue/first-attribute-linebreak': ['error', {
+			singleline: 'beside',
+			multiline: 'below',
+		}],
+		// Prevent conflicts with native HTML elements
+		'vue/multi-word-component-names': 'error',
+		// custom event naming convention
+		'vue/custom-event-name-casing': 'warning',
+	},
+}

--- a/vue3.js
+++ b/vue3.js
@@ -1,0 +1,41 @@
+const base = require('./parts/base.js')
+const typescriptOverrides = require('./parts/typescript.js')
+const vueOverrides = require('./parts/vue3.js')
+
+// Use different parser for vue files script section
+vueOverrides.parserOptions = {
+	parser: '@typescript-eslint/parser',
+	sourceType: 'module',
+}
+
+// Override vue rules with rules for Typescript
+vueOverrides.rules = {
+	...vueOverrides.rules,
+	...typescriptOverrides.rules,
+}
+
+// Add settings, required for import resolver
+vueOverrides.settings = {
+	...(vueOverrides.settings || []),
+	...typescriptOverrides.settings,
+}
+
+// Also extend from vue typescript eslint
+vueOverrides.extends.push('@vue/eslint-config-typescript/recommended')
+
+/**
+ * Config for projects written in Typescript + vue including vue files written in Typescript (`<script lang='ts'>`)
+ */
+module.exports = {
+	...base,
+	overrides: [
+		// Overrides for Typescript files
+		{
+			...typescriptOverrides,
+		},
+		// Setup different vue parser to support `<script setup>` correctly, especially for `lang="ts"`
+		{
+			...vueOverrides,
+		},
+	],
+}


### PR DESCRIPTION
This adds a new `vue3` sub-configuration so we can support vue 2 and vue 3 with this linter config.