### PR TITLE
fix(vue3): align rules with Vue 2 rules

### DIFF
--- a/parts/vue3.js
+++ b/parts/vue3.js
@@ -29,10 +29,10 @@ module.exports = {
 		// See https://vuejs.org/style-guide/rules-strongly-recommended.html#multi-attribute-elements
 		'vue/first-attribute-linebreak': ['error', {
 			singleline: 'beside',
-			multiline: 'below',
+			multiline: 'beside',
 		}],
-		// Prevent conflicts with native HTML elements
-		'vue/multi-word-component-names': 'error',
+		// Allow single-word components names
+		'vue/multi-word-component-names': ['off'],
 		// custom event naming convention
 		'vue/custom-event-name-casing': 'warning',
 	},


### PR DESCRIPTION
While I totally agree with the rules, they are much different from our rules for Vue 2 requiring having many formatting changes and even filenames between Vue 2 and Vue 3 apps. It makes diffs and backports complicated during migration period.