### PR TITLE
enh(git): ignore formatting commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+96662f16597bfe670fcb4a64575386874fefea9d


### PR DESCRIPTION
* 96662f1 contains whitespace changes only.

This file will be picked up automatically by github.
Instructions for configuring git locally are included in
`.git-blame-ignore-revs` file.
