### PR TITLE
fix(typescript): do not require returns type in jsdoc

### DIFF
--- a/parts/typescript.js
+++ b/parts/typescript.js
@@ -31,6 +31,8 @@ module.exports = {
 		],
 		// Does not make sense with TypeScript
 		'jsdoc/require-param-type': 'off',
+		'jsdoc/require-returns-type': 'off',
+		//
 		'@typescript-eslint/no-empty-function': 'off',
 	},
 	settings: {


### PR DESCRIPTION
Same as `jsdoc/require-param-type`