### PR TITLE
chore: prepare v8.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@
 -->	
 # Changelog
 
-## [v8.4.1](https://github.com/nextcloud-libraries/eslint-config/tree/v8.4.1) (2024-05-16)
+## [v8.4.2](https://github.com/nextcloud-libraries/eslint-config/tree/v8.4.2) (2025-02-16)
+### Fixed
+* fix(typescript): do not require returns type in jsdoc by @ShGKme in https://github.com/nextcloud-libraries/eslint-config/pull/857
 
+### Changed
+* Updated development dependencies
+* Add SPDX header  by @AndyScherzinger in https://github.com/nextcloud-libraries/eslint-config/pull/802
+* enh(git): ignore formatting commits in git blame by @max-nextcloud in https://github.com/nextcloud-libraries/eslint-config/pull/854
+
+## [v8.4.1](https://github.com/nextcloud-libraries/eslint-config/tree/v8.4.1) (2024-05-16)
 [Full Changelog](https://github.com/nextcloud-libraries/eslint-config/compare/v8.4.0...v8.4.1)
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/eslint-config",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/eslint-config",
-      "version": "8.4.1",
+      "version": "8.4.2",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.26.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/eslint-config",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "description": "Eslint shared config for nextcloud vue.js apps",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## [v8.4.2](https://github.com/nextcloud-libraries/eslint-config/tree/v8.4.2) (2025-02-16)
### Fixed
* fix(typescript): do not require returns type in jsdoc by @ShGKme in https://github.com/nextcloud-libraries/eslint-config/pull/857

### Changed
* Updated development dependencies
* Add SPDX header  by @AndyScherzinger in https://github.com/nextcloud-libraries/eslint-config/pull/802
* enh(git): ignore formatting commits in git blame by @max-nextcloud in https://github.com/nextcloud-libraries/eslint-config/pull/854