### PR TITLE
fix(codestyle): Enforce no space before function parenthesis

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -116,6 +116,19 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 					'error',
 					'never',
 				],
+				// No space between function name and parenthesis on definition. Enforce `function foo()` instead of `function foo ()`.
+				'@stylistic/space-before-function-paren': [
+					'error',
+					{
+						// good: `function() {}` bad: `function () {}`
+						anonymous: 'never',
+						// good `function foo() {}` bad: `function foo () {}`
+						named: 'never',
+						// consistency for arrow functions regardless of async or sync:
+						// good `async () => {}` bad `async() => {}`
+						asyncArrow: 'always',
+					},
+				],
 				// Enforce consistent newlines in function parameters, if one parameter is separated by newline, than all should
 				'@stylistic/function-call-argument-newline': [
 					'error',

--- a/tests/fixtures/codestyle/input/arrow-function.ts
+++ b/tests/fixtures/codestyle/input/arrow-function.ts
@@ -1,4 +1,11 @@
 /**
+ * An arrow function with missing space between `async` and the parenthesis
+ */
+const asyncArrow = async(name: string) => {
+	//
+}
+
+/**
  * An arrow function with the { on the wrong line
  */
 const arrow = (name: string) =>

--- a/tests/fixtures/codestyle/input/function.ts
+++ b/tests/fixtures/codestyle/input/function.ts
@@ -1,9 +1,18 @@
 /**
+ * A function with an additional space before the parenthesis
+ *
+ * @param name
+ */
+export function foo (name: string): boolean {
+	return true
+}
+
+/**
  * A function with the { on the wrong line
  *
  * @param name
  */
-export function foo(name: string): boolean
+export function bar(name: string): boolean
 {
 	return true
 }
@@ -14,7 +23,7 @@ export function foo(name: string): boolean
  * @param firstName
  * @param lastName
  */
-export function bar(
+export function baz(
 	firstName: string,
 	lastName: string,
 ): boolean
@@ -44,3 +53,18 @@ export function doSomethingDifferent(
 ) {
 	// ...
 }
+
+// Anonymous function with additional space before parenthesis
+const a = async function () {
+	// ...
+}
+
+// Tests for function calling
+
+// This is valid syntax
+doSomething(1, true)
+// This has an invalid space before the parenthesis
+doSomething (1, true)
+
+// invalid space for optional chaining
+a ?.()?. catch ?. (() => {})

--- a/tests/fixtures/codestyle/output/arrow-function.ts
+++ b/tests/fixtures/codestyle/output/arrow-function.ts
@@ -1,4 +1,13 @@
 /**
+ * An arrow function with missing space between `async` and the parenthesis
+ *
+ * @param name
+ */
+const asyncArrow = async (name: string) => {
+	//
+}
+
+/**
  * An arrow function with the { on the wrong line
  *
  * @param name

--- a/tests/fixtures/codestyle/output/function.ts
+++ b/tests/fixtures/codestyle/output/function.ts
@@ -1,9 +1,18 @@
 /**
- * A function with the { on the wrong line
+ * A function with an additional space before the parenthesis
  *
  * @param name
  */
 export function foo(name: string): boolean {
+	return true
+}
+
+/**
+ * A function with the { on the wrong line
+ *
+ * @param name
+ */
+export function bar(name: string): boolean {
 	return true
 }
 
@@ -13,7 +22,7 @@ export function foo(name: string): boolean {
  * @param firstName
  * @param lastName
  */
-export function bar(
+export function baz(
 	firstName: string,
 	lastName: string,
 ): boolean {
@@ -42,3 +51,18 @@ export function doSomething(
 export function doSomethingDifferent(num: number, enable: boolean) {
 	// ...
 }
+
+// Anonymous function with additional space before parenthesis
+const a = async function() {
+	// ...
+}
+
+// Tests for function calling
+
+// This is valid syntax
+doSomething(1, true)
+// This has an invalid space before the parenthesis
+doSomething(1, true)
+
+// invalid space for optional chaining
+a?.()?.catch?.(() => {})


### PR DESCRIPTION
As per code style: https://docs.nextcloud.com/server/latest/developer_manual/getting_started/coding_standards/javascript.html#code-style

Good:
- `function foo() {}`
- `function() {}`
- `foo()`

Bad:
- `function foo () {}`
- `function () {}`
- `foo ()`