### PR TITLE
fix(codeStyle): Adjust `stylistic` rules config

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -29,7 +29,6 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 				...GLOB_FILES_VUE,
 			],
 			...stylistic.configs.customize({
-				flat: true,
 				indent: 'tab',
 				semi: false,
 				quotes: 'single',


### PR DESCRIPTION
* Issue of https://github.com/nextcloud-libraries/eslint-config/pull/902

The `flat` option is now always enabled and does not exist anymore.