### PR TITLE
feat: introduce @nextcloud/vue eslint plugin

### DIFF
--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -6,7 +6,12 @@ import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
 import vuePlugin from 'eslint-plugin-vue'
-import { GLOB_FILES_VUE } from '../globs.ts'
+import {
+	GLOB_FILES_JAVASCRIPT,
+	GLOB_FILES_TYPESCRIPT,
+	GLOB_FILES_VUE,
+} from '../globs.ts'
+import nextcloudVuePlugin from '../plugins/nextcloud-vue/index.ts'
 import { codeStyle } from './codeStyle.ts'
 
 const stylisticRules = codeStyle({
@@ -126,6 +131,21 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 				'vue/padding-line-between-blocks': 'error',
 			},
 			name: 'nextcloud/vue/stylistic-rules',
+		},
+
+		{
+			files: [
+				...GLOB_FILES_JAVASCRIPT,
+				...GLOB_FILES_TYPESCRIPT,
+				...GLOB_FILES_VUE,
+			],
+			plugins: {
+				'@nextcloud/vue': nextcloudVuePlugin,
+			},
+			rules: {
+				'@nextcloud/vue/no-deprecated-exports': 'error',
+			},
+			name: 'nextcloud/vue/migration-rules',
 		},
 	]
 }

--- a/lib/plugins/nextcloud-vue/index.ts
+++ b/lib/plugins/nextcloud-vue/index.ts
@@ -1,0 +1,16 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { ESLint } from 'eslint'
+
+import { packageVersion } from '../../version.ts'
+import { rules } from './rules/index.ts'
+
+export default {
+	rules,
+	meta: {
+		name: '@nextcloud/eslint-plugin',
+		version: packageVersion,
+	},
+} satisfies ESLint.Plugin

--- a/lib/plugins/nextcloud-vue/rules/index.ts
+++ b/lib/plugins/nextcloud-vue/rules/index.ts
@@ -1,0 +1,11 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { Rule } from 'eslint'
+
+import noDeprecatedExports from './no-deprecated-exports.ts'
+
+export const rules: Record<string, Rule.RuleModule> = {
+	'no-deprecated-exports': noDeprecatedExports,
+}

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
@@ -1,0 +1,146 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { RuleTester } from 'eslint'
+import { fs, vol } from 'memfs'
+import { afterAll, beforeAll, describe, test, vi } from 'vitest'
+import rule from './no-deprecated-exports.ts'
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+vi.mock('node:fs', () => fs)
+
+describe('no-deprecated-exports', () => {
+	beforeAll(() => vol.fromNestedJSON({
+		[__dirname]: {},
+		[__filename]: '...',
+	}))
+	afterAll(() => vol.reset())
+
+	const ruleTester = new RuleTester()
+
+	test('no-deprecated-exports if library is not in use', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0"}',
+				src: { },
+			},
+		}, '/a/src')
+		ruleTester.run('no-deprecated-exports', rule, {
+			valid: [
+				{
+					code: "import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'",
+					filename: '/a/src/component.js',
+				},
+			],
+			invalid: [],
+		})
+	})
+
+	test('no-deprecated-exports if library has outdated version', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.22.0"}}',
+				src: { },
+			},
+		})
+		ruleTester.run('no-deprecated-exports', rule, {
+			valid: [
+				{
+					code: "import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'",
+					filename: '/a/src/component.js',
+				},
+			],
+			invalid: [],
+		})
+	})
+
+	test('no-deprecated-exports', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
+				src: { },
+			},
+		})
+		ruleTester.run('no-deprecated-exports', rule, {
+			valid: [
+				{
+					code: "import NcButton from '@nextcloud/vue/components/NcButton'",
+					filename: '/a/src/component.js',
+				},
+			],
+
+			invalid: [
+				{
+					code: "import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'",
+					filename: '/a/src/component.js',
+					errors: [
+						{
+							message: 'Import from "@nextcloud/vue/dist" is deprecated',
+							type: 'ImportDeclaration',
+						},
+					],
+					output: 'import NcButton from \'@nextcloud/vue/components/NcButton\'',
+				},
+				{
+					code: "import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'",
+					filename: '/a/src/component.js',
+					errors: [
+						{
+							message: 'Import from "@nextcloud/vue/dist" is deprecated',
+							type: 'ImportDeclaration',
+						},
+					],
+					output: 'import Tooltip from \'@nextcloud/vue/directives/Tooltip\'',
+				},
+				{
+					code: "import { emojiSearch } from '@nextcloud/vue/dist/Functions/emoji.js'",
+					filename: '/a/src/component.js',
+					errors: [
+						{
+							message: 'Import from "@nextcloud/vue/dist" is deprecated',
+							type: 'ImportDeclaration',
+						},
+					],
+					output: 'import { emojiSearch } from \'@nextcloud/vue/functions/emoji\'',
+				},
+				{
+					code: "import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'",
+					filename: '/a/src/component.js',
+					errors: [
+						{
+							message: 'Import from "@nextcloud/vue/dist" is deprecated',
+							type: 'ImportDeclaration',
+						},
+					],
+					output: 'import { useHotKey } from \'@nextcloud/vue/composables/useHotKey\'',
+				},
+				{
+					code: "import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey/index.js'",
+					filename: '/a/src/component.js',
+					errors: [
+						{
+							message: 'Import from "@nextcloud/vue/dist" is deprecated',
+							type: 'ImportDeclaration',
+						},
+					],
+					output: 'import { useHotKey } from \'@nextcloud/vue/composables/useHotKey\'',
+				},
+				{
+					code: "import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'",
+					filename: '/a/src/component.js',
+					errors: [
+						{
+							message: 'Import from "@nextcloud/vue/dist" is deprecated',
+							type: 'ImportDeclaration',
+						},
+					],
+					output: 'import isMobile from \'@nextcloud/vue/mixins/isMobile\'',
+				},
+			],
+		})
+	})
+})

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
@@ -1,0 +1,59 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { Rule } from 'eslint'
+
+import { createLibVersionValidator } from '../utils/lib-version-parser.ts'
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+/*
+ Introduced in @nextcloud/vue v8.23.0
+ https://github.com/nextcloud-libraries/nextcloud-vue/pull/6385
+ */
+
+const rule: Rule.RuleModule = {
+	meta: {
+		docs: {
+			description: 'Deprecated @nextcloud/vue import syntax',
+			recommended: true,
+		},
+		fixable: 'code',
+		schema: [],
+	},
+
+	create(context) {
+		const versionSatisfies = createLibVersionValidator(context)
+		const isVersionValid = versionSatisfies('8.23.0')
+
+		const oldPattern = '@nextcloud/vue/dist/([^/]+)/([^/.]+)'
+
+		return {
+			ImportDeclaration: function(node) {
+				if (!isVersionValid) {
+					// Can't fix, ignore the rule
+					return
+				}
+
+				const importPath = node.source.value as string
+				const match = importPath.match(new RegExp(oldPattern))
+
+				if (match) {
+					const newImportPath = `'@nextcloud/vue/${match[1].toLowerCase()}/${match[2]}'`
+					context.report({
+						node,
+						message: 'Import from "@nextcloud/vue/dist" is deprecated',
+						fix(fixer) {
+							return fixer.replaceText(node.source, newImportPath)
+						},
+					})
+				}
+			},
+		}
+	},
+}
+
+export default rule

--- a/lib/plugins/nextcloud-vue/utils/lib-version-parser.test.ts
+++ b/lib/plugins/nextcloud-vue/utils/lib-version-parser.test.ts
@@ -1,0 +1,177 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { fs, vol } from 'memfs'
+import { join } from 'node:path'
+import { afterAll, afterEach, beforeAll, describe, expect, it, test, vi } from 'vitest'
+import {
+	createLibVersionValidator,
+	findPackageJsonDir,
+	isFile,
+	sanitizeTargetVersion,
+} from './lib-version-parser.ts'
+
+vi.mock('node:fs', () => fs)
+
+describe('version-parser', () => {
+	beforeAll(() => vol.fromNestedJSON({
+		[__dirname]: {},
+		[__filename]: '...',
+	}))
+	afterAll(() => vol.reset())
+
+	test('isFile', () => {
+		expect(isFile(__dirname)).toBe(false)
+		expect(isFile(__filename)).toBe(true)
+		expect(isFile(join(__dirname, 'does-not-exists.invalid'))).toBe(false)
+	})
+
+	test('sanitizeTargetVersion', () => {
+		expect(sanitizeTargetVersion('^23.0.0')).toBe('23.0.0')
+		expect(sanitizeTargetVersion('25.0')).toBe('25.0.0')
+		expect(sanitizeTargetVersion('25.0.1')).toBe('25.0.1')
+
+		try {
+			const output = sanitizeTargetVersion('a.b.c')
+			expect(output).toBe('Should not be reached')
+		} catch (e) {
+			expect(e.message).toMatch(/Invalid comparator/)
+		}
+
+		try {
+			const output = sanitizeTargetVersion('25.0.0.1')
+			expect(output).toBe('Should not be reached')
+		} catch (e) {
+			expect(e.message).toMatch(/Invalid comparator/)
+		}
+	})
+
+	describe('findPackageJsonDir', () => {
+		afterEach(() => vol.reset())
+
+		it('finds a package.json if provided', () => {
+			vol.fromNestedJSON({
+				'/a': {
+					'package.json': '...',
+					src: {},
+				},
+			})
+
+			expect(findPackageJsonDir('/a/src')).toBe('/a')
+		})
+
+		it('finds a package.json if provided on lower directory', () => {
+			vol.fromNestedJSON({
+				'/a': {
+					'package.json': '...',
+					src: {
+						b: {
+							c: {},
+						},
+					},
+				},
+			})
+
+			expect(findPackageJsonDir('/a/src/b/c')).toBe('/a')
+		})
+
+		it('returns undefined if not found', () => {
+			vol.fromNestedJSON({
+				'/a/src/b/c': {},
+			})
+
+			expect(findPackageJsonDir('/a/src/b/c')).toBe(undefined)
+		})
+	})
+
+	describe('createLibVersionValidator', () => {
+		it('no config', () => {
+			const fn = createLibVersionValidator({
+				cwd: '',
+				physicalFilename: '',
+			})
+			expect(fn('8.22.0')).toBe(false)
+			expect(fn('8.23.0')).toBe(false)
+			expect(fn('8.23.1')).toBe(false)
+			expect(fn('8.24.0')).toBe(false)
+			expect(fn('9.0.0')).toBe(false)
+		})
+
+		describe('package.json', () => {
+			afterEach(() => vol.reset())
+
+			it('returns false without nextcloud/vue in dependencies', () => {
+				vol.fromNestedJSON({
+					'/a': {
+						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{}}',
+						src: { },
+					},
+				})
+				const fn = createLibVersionValidator({
+					cwd: '',
+					physicalFilename: '/a/src/b.js',
+				})
+				expect(fn('8.22.0')).toBe(false)
+				expect(fn('8.23.0')).toBe(false)
+				expect(fn('8.23.1')).toBe(false)
+				expect(fn('8.24.0')).toBe(false)
+				expect(fn('9.0.0')).toBe(false)
+			})
+
+			it('works with physical filename', () => {
+				vol.fromNestedJSON({
+					'/a': {
+						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
+						src: { },
+					},
+				})
+				const fn = createLibVersionValidator({
+					cwd: '',
+					physicalFilename: '/a/src/b.js',
+				})
+				expect(fn('8.22.0')).toBe(true)
+				expect(fn('8.23.0')).toBe(true)
+				expect(fn('8.23.1')).toBe(true)
+				expect(fn('8.24.0')).toBe(false)
+				expect(fn('9.0.0')).toBe(false)
+			})
+
+			it('works with cwd', () => {
+				vol.fromNestedJSON({
+					'/a': {
+						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
+						src: { },
+					},
+				})
+				const fn = createLibVersionValidator({
+					cwd: '/a',
+					physicalFilename: 'src/b.js',
+				})
+				expect(fn('8.22.0')).toBe(true)
+				expect(fn('8.23.0')).toBe(true)
+				expect(fn('8.23.1')).toBe(true)
+				expect(fn('8.24.0')).toBe(false)
+				expect(fn('9.0.0')).toBe(false)
+			})
+
+			it('works with several dependency sources', () => {
+				vol.fromNestedJSON({
+					'/a': {
+						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.24.0"},"devDependencies":{"@nextcloud/vue":"^8.24.0"},"peerDependencies":{"@nextcloud/vue":"^8.23.1"}}',
+						src: { },
+					},
+				})
+				const fn = createLibVersionValidator({
+					cwd: '/a',
+					physicalFilename: 'src/b.js',
+				})
+				expect(fn('8.22.0')).toBe(true)
+				expect(fn('8.23.0')).toBe(true)
+				expect(fn('8.23.1')).toBe(true)
+				expect(fn('8.24.0')).toBe(false)
+				expect(fn('9.0.0')).toBe(false)
+			})
+		})
+	})
+})

--- a/lib/plugins/nextcloud-vue/utils/lib-version-parser.ts
+++ b/lib/plugins/nextcloud-vue/utils/lib-version-parser.ts
@@ -1,0 +1,102 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { lstatSync, readFileSync } from 'node:fs'
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
+import { gte, minVersion, valid } from 'semver'
+
+/**
+ * Cached map of paths: Reco <path_to_package.json, validator>
+ */
+const cachedMap: Record<string, (version: string) => boolean> = {}
+
+/**
+ * Check if a given path exists and is a file
+ *
+ * @param filePath The path
+ */
+export function isFile(filePath: string): boolean {
+	const stats = lstatSync(filePath, { throwIfNoEntry: false })
+	return stats !== undefined && stats.isFile()
+}
+
+/**
+ * Find the path of nearest `package.json` relative to given path
+ *
+ * @param currentPath Path to lookup
+ * @return Either the full path where `package.json` is located or `undefined` if no found
+ */
+export function findPackageJsonDir(currentPath: string): string | undefined {
+	for (const cachedDirPath of Object.keys(cachedMap)) {
+		if (currentPath.startsWith(cachedDirPath)) {
+			return cachedDirPath
+		}
+	}
+	while (currentPath && currentPath !== sep) {
+		if (isFile(join(currentPath, 'package.json'))) {
+			return currentPath
+		}
+		currentPath = resolve(currentPath, '..')
+	}
+	return undefined
+}
+
+/**
+ * Make sure that versions like '25' can be handled by semver
+ *
+ * @param version The pure version string
+ * @return Sanitized version string
+ */
+export function sanitizeTargetVersion(version: string): string {
+	const sanitizedVersion = minVersion(version)?.version
+	// now version should look like '23.0.0'
+	if (!valid(sanitizedVersion)) {
+		throw Error(`[@nextcloud/eslint-plugin] Invalid target version ${version} found`)
+	}
+	return sanitizedVersion
+}
+
+/**
+ * Create a callback that takes a version number and checks if the version
+ * is valid compared to configured version / detected version.
+ *
+ * @param options Options
+ * @param options.cwd The current working directory
+ * @param options.physicalFilename The real filename where ESLint is linting currently
+ * @return Function validator, return a boolean whether current version satisfies minimal required for the rule
+ */
+export function createLibVersionValidator({ cwd, physicalFilename }): ((version: string) => boolean) {
+	// Try to find package.json and parse the supported version
+	// Current working directory, either the filename (can be empty) or the cwd property
+	const currentDirectory = isAbsolute(physicalFilename)
+		? resolve(dirname(physicalFilename))
+		: dirname(resolve(cwd, physicalFilename))
+
+	// The nearest package.json
+	const packageJsonDir = findPackageJsonDir(currentDirectory)
+	if (!packageJsonDir) {
+		// Skip the rule
+		return () => false
+	} else if (cachedMap[packageJsonDir]) {
+		return cachedMap[packageJsonDir]
+	}
+
+	const json = JSON.parse(readFileSync(join(packageJsonDir, 'package.json'), 'utf-8'))
+	const libVersions = [
+		json?.dependencies?.['@nextcloud/vue'],
+		json?.devDependencies?.['@nextcloud/vue'],
+		json?.peerDependencies?.['@nextcloud/vue'],
+	]
+		.filter((version) => typeof version === 'string' && !!version)
+		.map(sanitizeTargetVersion)
+		.sort((a, b) => gte(a, b) ? 1 : -1)
+
+	if (!libVersions.length) {
+		// Skip the rule
+		return () => false
+	}
+
+	// Return, whether given version satisfies minimal version from dependencies
+	return (version: string) => gte(libVersions[0], version)
+}


### PR DESCRIPTION
POC to see if we can handle deprecated parameters and practices in `nextcloud/vue@9.x.x`

![image](https://github.com/user-attachments/assets/59334fa5-ac18-4426-8c71-d926a19fdc86)

TODO:
- [x] should be included in .js|.ts files?
- [ ] discuss what's worth efforts to be highlighted with `eslint`
- [ ] discuss what's worth efforts to be handled with `eslint --fix`
- [ ] find the first release in `nextcloud/vue@8.x.x` we started to deprecate something for the `next` branch that's worth linting