### PR TITLE
feat: enforce non-breaking spaces before ellipsis for translations

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -4,13 +4,15 @@
  */
 
 import type { Linter } from 'eslint'
-import stylistic from '@stylistic/eslint-plugin'
 import {
 	GLOB_FILES_JAVASCRIPT,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
 import { ConfigOptions } from '../types'
+
+import stylistic from '@stylistic/eslint-plugin'
+import l10nPlugin from '../plugins/l10n/index.ts'
 
 /**
  * Config factory for general code style related rules
@@ -40,6 +42,7 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 		},
 
 		{
+			name: 'nextcloud/stylistic/rules',
 			files: [
 				...GLOB_FILES_JAVASCRIPT,
 				...GLOB_FILES_TYPESCRIPT,
@@ -160,10 +163,10 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 				// Prefer { ...foo } over Object.assign({}, foo)
 				'prefer-object-spread': 'warn',
 			},
-			name: 'nextcloud/stylistic/rules',
 		},
 
 		{
+			name: 'nextcloud/stylistic/ts-rules',
 			files: [
 				...GLOB_FILES_TYPESCRIPT,
 				...(options.vueIsTypescript ? GLOB_FILES_VUE : []),
@@ -175,7 +178,23 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 				'@stylistic/type-generic-spacing': 'error',
 				'@stylistic/type-named-tuple-spacing': 'error',
 			},
-			name: 'nextcloud/stylistic/ts-rules',
+		},
+
+		{
+			name: 'nextcloud/stylistic/l10n',
+			files: [
+				...GLOB_FILES_JAVASCRIPT,
+				...GLOB_FILES_TYPESCRIPT,
+				...GLOB_FILES_VUE,
+			],
+			plugins: {
+				'@nextcloud-l10n': l10nPlugin,
+			},
+			// Enforce that translations use ellipsis instead of tripple dots
+			rules: {
+				'@nextcloud-l10n/non-breaking-space': 'error',
+				'@nextcloud-l10n/enforce-ellipsis': 'error',
+			},
 		},
 	]
 }

--- a/lib/plugins/l10n/index.ts
+++ b/lib/plugins/l10n/index.ts
@@ -1,0 +1,24 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ESLint } from 'eslint'
+import RuleEllipsis from './rules/enforce-ellipsis.ts'
+import RuleNonBreakingSpace from './rules/non-breaking-space.ts'
+
+/**
+ * ESLint plugin to enforce consistent translations
+ */
+const Plugin: ESLint.Plugin = {
+	meta: {
+		name: '@nextcloud/l10n-plugin',
+		version: __PACKAGE_VERSION__,
+	},
+	rules: {
+		'non-breaking-space': RuleNonBreakingSpace,
+		'enforce-ellipsis': RuleEllipsis,
+	},
+}
+
+export default Plugin

--- a/lib/plugins/l10n/rules/enforce-ellipsis.test.ts
+++ b/lib/plugins/l10n/rules/enforce-ellipsis.test.ts
@@ -1,0 +1,72 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { RuleTester } from 'eslint'
+import { test } from 'vitest'
+import rule from './enforce-ellipsis.ts'
+
+test('rule: enforce-ellipsis', () => {
+	const ruleTester = new RuleTester()
+
+	ruleTester.run('enforce-ellipsis', rule, {
+		/* eslint-disable @nextcloud-l10n/non-breaking-space */
+		valid: [
+			{
+				code: "const foo = '..... done'",
+			},
+			{
+				code: "const foo = 'file/..'",
+			},
+			{
+				code: '// ...',
+			},
+			{
+				code: 'const foo = { ...bar }',
+			},
+		],
+
+		invalid: [
+			{
+				code: 't("Loading...")',
+				output: 't("Loading…")',
+				errors: [
+					{
+						type: 'Literal',
+						message: 'Strings should ellipsis instead of triple dots',
+					},
+				],
+			},
+			{
+				code: 't("files", "Loading...")',
+				output: 't("files", "Loading…")',
+				errors: [
+					{
+						type: 'Literal',
+						message: 'Strings should ellipsis instead of triple dots',
+					},
+				],
+			},
+			{
+				code: "t('Loading ...')",
+				output: "t('Loading …')",
+				errors: [
+					{
+						type: 'Literal',
+						message: 'Strings should ellipsis instead of triple dots',
+					},
+				],
+			},
+			{
+				code: 'const txt = "Checking status ..."',
+				output: 'const txt = "Checking status …"',
+				errors: [
+					{
+						type: 'Literal',
+						message: 'Strings should ellipsis instead of triple dots',
+					},
+				],
+			},
+		],
+	})
+})

--- a/lib/plugins/l10n/rules/enforce-ellipsis.ts
+++ b/lib/plugins/l10n/rules/enforce-ellipsis.ts
@@ -1,0 +1,42 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { Rule } from 'eslint'
+
+const defineRule = (r: Rule.RuleModule) => r
+
+export default defineRule({
+	meta: {
+		fixable: 'code',
+		type: 'suggestion',
+		schema: [],
+		docs: {
+			description: 'Enforce consistent translation format for Nextcloud',
+		},
+	},
+
+	create(context) {
+		return {
+			Literal(node) {
+				if (typeof node.value !== 'string'
+					|| node.parent.type !== 'CallExpression'
+					|| node.parent.callee.type !== 'Identifier'
+					|| node.parent.callee.name !== 't'
+				) {
+					return
+				}
+
+				if (node.raw?.match(/(?<=[^.])\.\.\.(?!\.)/)) {
+					context.report({
+						node,
+						message: 'Strings should ellipsis instead of triple dots',
+						fix(fixer) {
+							return fixer.replaceText(node, node.raw!.replaceAll(/(?<=[^.])\.\.\.(?!\.)/g, '…'))
+						},
+					})
+				}
+			},
+		}
+	},
+})

--- a/lib/plugins/l10n/rules/non-breaking-space.test.ts
+++ b/lib/plugins/l10n/rules/non-breaking-space.test.ts
@@ -1,0 +1,54 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable @nextcloud-l10n/non-breaking-space */
+import { RuleTester } from 'eslint'
+import { test } from 'vitest'
+import rule from './non-breaking-space.ts'
+
+test('rule: non-breaking-space', () => {
+	const ruleTester = new RuleTester()
+
+	ruleTester.run('non-breaking-space', rule, {
+		valid: [
+			{
+				code: "t('files', 'Loading …')",
+			},
+			{
+				code: "const foo = 'Loading …'",
+			},
+			{
+				code: "const foo = 'Loading…'",
+			},
+			{
+				code: "const foo = 'Loading ...'",
+			},
+		],
+
+		invalid: [
+			{
+				code: "t('files', 'Loading …')",
+				output: "t('files', 'Loading …')",
+				errors: [
+					{
+						type: 'Literal',
+						message: 'Ellipsis must be preceded by non-breaking spaces',
+					},
+				],
+			},
+			{
+				// eslint-disable-next-line @stylistic/no-tabs
+				code: "const foo = 'Loading	…'",
+				output: "const foo = 'Loading …'",
+				errors: [
+					{
+						type: 'Literal',
+						message: 'Ellipsis must be preceded by non-breaking spaces',
+					},
+				],
+			},
+		],
+	})
+})

--- a/lib/plugins/l10n/rules/non-breaking-space.ts
+++ b/lib/plugins/l10n/rules/non-breaking-space.ts
@@ -1,0 +1,39 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { Rule } from 'eslint'
+
+const defineRule = (r: Rule.RuleModule) => r
+
+export default defineRule({
+	meta: {
+		fixable: 'code',
+		type: 'suggestion',
+		schema: [],
+		docs: {
+			description: 'Enforce non-breaking spaces before ellipsis',
+		},
+	},
+
+	create(context) {
+		return {
+			Literal(node) {
+				if (typeof node.value !== 'string') {
+					return
+				}
+
+				const matches = node.value.match(/(\s+)…/)
+				if (matches && matches[1] !== ' ') {
+					context.report({
+						node,
+						message: 'Ellipsis must be preceded by non-breaking spaces',
+						fix(fixer) {
+							return fixer.replaceText(node, node.raw.replaceAll(/\s+…/g, ' …'))
+						},
+					})
+				}
+			},
+		}
+	},
+})


### PR DESCRIPTION
* Resolves #9 

1. Enforce ellipsis instead of tipple dots for translations
2. Enforce non breaking spaces instead of normal spaces before ellipsis