### PR TITLE
fix(typescript): allow to use function before definition

### DIFF
--- a/lib/configs/typescript.ts
+++ b/lib/configs/typescript.ts
@@ -42,7 +42,12 @@ export function typescript(options: ConfigOptions): Linter.Config[] {
 				'@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',
 				// Do not use types, variables etc before they are defined
 				'no-use-before-define': 'off',
-				'@typescript-eslint/no-use-before-define': 'error',
+				'@typescript-eslint/no-use-before-define': [
+					'error',
+					{
+						functions: false,
+					},
+				],
 				// Do not shadow outer variables / functions - this can lead to wrong assumptions
 				'no-shadow': 'off',
 				'@typescript-eslint/no-shadow': 'error',

--- a/tests/config-typescript.test.ts
+++ b/tests/config-typescript.test.ts
@@ -33,3 +33,13 @@ test('Typescript overrides have higher priority than vue', async () => {
 		line: 15,
 	})
 })
+
+test('Typescript no-use-before-define allows functions', async () => {
+	const results = await lintFile('fixtures/use-before-define.ts')
+
+	expect(results).toHaveIssueCount(1)
+	expect(results).toHaveIssue({
+		ruleId: '@typescript-eslint/no-use-before-define',
+		line: 7,
+	})
+})

--- a/tests/fixtures/use-before-define.ts
+++ b/tests/fixtures/use-before-define.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+// This is invalid because a is an arrow function and will not be defined before execution
+export const b = `${a()}...`
+const a = () => 'a'
+
+// This is valid to use a function before define due to the function keyword it is defined before execution
+export const d = c()
+
+/**
+ * Random function
+ */
+function c() {
+	return 'c'
+}


### PR DESCRIPTION
This allows to write code in reading order - perfectly fine from syntax as `function` will be defined before executing the file anyways.