### PR TITLE
fix(codestyle): adjust empty lines style

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -95,13 +95,19 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 					'error',
 					{
 						multiline: true,
-						minItems: 2,
+						minItems: null, // disable
 					},
 				],
-				// Enforce new lines between array elements (better git diff)
+				// Enforce new lines between array elements (better git diff) but allow to have single line arrays for array parameters
 				'@stylistic/array-element-newline': [
 					'error',
-					'always',
+					{
+						ArrayExpression: 'always',
+						ArrayPattern: {
+							consistent: true,
+							multiline: true,
+						},
+					},
 				],
 				// Same for objects as for arrays
 				'@stylistic/object-curly-newline': [

--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -123,6 +123,8 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 				],
 				// Consistent style of props
 				'vue/new-line-between-multi-line-property': 'error',
+				// Add consistent padding between blocks
+				'vue/padding-line-between-blocks': 'error',
 			},
 			name: 'nextcloud/vue/stylistic-rules',
 		},


### PR DESCRIPTION
- Vue shall have empty lines between blocks
- Do not enforce array elements on empty lines but be consistent