### PR TITLE
fix(javascript): allow using functions before they are defined

### DIFF
--- a/lib/configs/javascript.ts
+++ b/lib/configs/javascript.ts
@@ -109,7 +109,10 @@ export function javascript(options: ConfigOptions): Linter.Config[] {
 				// We support ES2022 so we should use `hasOwn` instead
 				'prefer-object-has-own': 'error',
 				// Allow to write code in reading order for functions
-				'no-use-before-define': ['error'],
+				'no-use-before-define': [
+					'error',
+					{ functions: false },
+				],
 			},
 		},
 


### PR DESCRIPTION
`function`, similar as `var`, are special ECMAscript. They will be defined at any position in the script even if they are defined after usage.