### PR TITLE
fix(globs): properly ignore test files

### DIFF
--- a/lib/globs.ts
+++ b/lib/globs.ts
@@ -5,9 +5,9 @@
 
 /** Glob pattern for test files (specs) */
 export const GLOB_FILES_TESTING = [
-	'**.test.*',
-	'**.spec.*',
-	'**.cy.*',
+	'**/*.test.*',
+	'**/*.spec.*',
+	'**/*.cy.*',
 	'**/test',
 	'**/tests',
 ]


### PR DESCRIPTION
While testing the configurations in some apps I noticed JSdoc rules are not properly disabled in test files.
Adjusting the glob did help.