### PR TITLE
chore: allow to run `npm lint` without compile step

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-import { recommended } from './dist/index.js'
+import { recommended } from './lib/index.ts'
 
 export default [
 	{

--- a/lib/configs/documentation.ts
+++ b/lib/configs/documentation.ts
@@ -10,7 +10,7 @@ import {
 	GLOB_FILES_TESTING,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
-} from '../globs.js'
+} from '../globs.ts'
 import jsdocPlugin from 'eslint-plugin-jsdoc'
 
 /**

--- a/lib/plugins/nextcloud/rules/no-removed-apis.ts
+++ b/lib/plugins/nextcloud/rules/no-removed-apis.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { Rule, Scope } from 'eslint'
+import type { Rule, Scope } from 'eslint'
 import { createVersionValidator } from '../utils/version-parser.ts'
 
 // ------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "build": "npm run build:cleanup && npm run build:source",
     "build:cleanup": "tsc --build --clean",
     "build:source": "tsc",
-    "lint": "npm run build && eslint",
-    "lint:fix": "eslint --fix",
+    "lint": "npx --node-options='--experimental-strip-types' eslint --flag unstable_native_nodejs_ts_config",
+    "lint:fix": "npx --node-options='--experimental-strip-types' eslint --flag unstable_native_nodejs_ts_config --fix",
     "test": "vitest run"
   },
   "dependencies": {
@@ -72,7 +72,7 @@
     },
     "runtime": {
       "name": "node",
-      "version": "^22"
+      "version": "^22.10"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"declaration": true,
 		"esModuleInterop": true,
+		"erasableSyntaxOnly": true,
 		"rewriteRelativeImportExtensions": true,
 		"resolveJsonModule": true,
 		"moduleResolution": "NodeNext",


### PR DESCRIPTION
Just bump our development version of node to 22.10+ so we can directly use Typescript as the configuration format.