### PR TITLE
feat(imports): sort imports in a consistent way

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -2,16 +2,16 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import stylistic from '@stylistic/eslint-plugin'
 
 import {
 	GLOB_FILES_JAVASCRIPT,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
-
-import stylistic from '@stylistic/eslint-plugin'
 import l10nPlugin from '../plugins/l10n/index.ts'
 
 /**
@@ -91,6 +91,7 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 				],
 
 				// Enforce new lines after [ and before ] if there are multiline entries or more than 1 item in the array (better git diff)
+				// TODO: Adjust once implemented: https://github.com/eslint-stylistic/eslint-stylistic/issues/761
 				'@stylistic/array-bracket-newline': [
 					'error',
 					{

--- a/lib/configs/documentation.ts
+++ b/lib/configs/documentation.ts
@@ -57,7 +57,7 @@ export function documentation(options: ConfigOptions): Linter.Config[] {
 
 		{
 			rules: {
-			// Force proper documentation
+				// Force proper documentation
 				'jsdoc/check-tag-names': 'error',
 				// But ignore return values
 				'jsdoc/require-returns': 'off',
@@ -87,7 +87,7 @@ export function documentation(options: ConfigOptions): Linter.Config[] {
 
 		{
 			rules: {
-			// Overwrites for documentation as types are already provided by Typescript
+				// Overwrites for documentation as types are already provided by Typescript
 				'jsdoc/require-param-type': 'off',
 				'jsdoc/require-property-type': 'off',
 				'jsdoc/require-returns-type': 'off',

--- a/lib/configs/imports.ts
+++ b/lib/configs/imports.ts
@@ -87,6 +87,53 @@ export const imports: Linter.Config[] = [
 			'import/first': 'error',
 			// Require a newline after each import (so not multiple `import` statements on the same line)
 			'import/newline-after-import': 'error',
+			// Consistent import order
+			'import/order': [
+				'error',
+				{
+					groups: [
+						'type',
+						[
+							'builtin',
+							'external',
+						],
+						'internal',
+						[
+							'parent',
+							'sibling',
+							'index',
+						],
+						'unknown',
+					],
+					pathGroups: [
+						{
+						// group all style imports at the end
+							pattern: '{*.css,*.scss}',
+							patternOptions: { matchBase: true },
+							group: 'unknown',
+							position: 'after',
+						},
+						{
+							// group components
+							pattern: '*.vue',
+							patternOptions: { matchBase: true },
+							group: 'parent',
+							position: 'before',
+						},
+					],
+					// needed so that 'vue-material-design-icons' are considered components
+					pathGroupsExcludedImportTypes: ['builtin'],
+					'newlines-between': 'always',
+					alphabetize: {
+						order: 'asc',
+					},
+					named: true,
+					// enable with next eslint-plugin-import release
+					// sortTypesGroup: true,
+					// 'newlines-between-types': 'never',
+					warnOnUnassignedImports: true,
+				},
+			],
 		},
 	},
 ]

--- a/lib/configs/javascript.ts
+++ b/lib/configs/javascript.ts
@@ -2,8 +2,11 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import eslintRules from '@eslint/js'
+import globals from 'globals'
 
 import {
 	GLOB_FILES_JAVASCRIPT,
@@ -11,9 +14,6 @@ import {
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
-
-import eslintRules from '@eslint/js'
-import globals from 'globals'
 import nextcloudPlugin from '../plugins/nextcloud/index.ts'
 
 /**

--- a/lib/configs/json.ts
+++ b/lib/configs/json.ts
@@ -4,13 +4,13 @@
  */
 import type { ESLint, Linter } from 'eslint'
 
+import jsonPlugin from '@eslint/json'
+
 import {
 	GLOB_FILES_JSON,
 	GLOB_FILES_JSONC,
 	GLOB_FILES_MS_JSON,
 } from '../globs.ts'
-
-import jsonPlugin from '@eslint/json'
 import packageJsonPlugin from '../plugins/packageJson.ts'
 
 /**

--- a/lib/configs/node.ts
+++ b/lib/configs/node.ts
@@ -4,8 +4,9 @@
  */
 import type { Linter } from 'eslint'
 
-import { GLOB_FILES_TESTING } from '../globs.ts'
 import globals from 'globals'
+
+import { GLOB_FILES_TESTING } from '../globs.ts'
 
 /**
  * Config setup for the node environment.

--- a/lib/configs/typescript.ts
+++ b/lib/configs/typescript.ts
@@ -2,8 +2,10 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import typescriptPlugin from 'typescript-eslint'
 
 import {
 	GLOB_FILES_TESTING,
@@ -11,8 +13,6 @@ import {
 	GLOB_FILES_VUE,
 } from '../globs.ts'
 import { restrictConfigFiles } from '../utils.ts'
-
-import typescriptPlugin from 'typescript-eslint'
 
 /**
  * Typescript related ESLint rules for Nextcloud

--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -2,13 +2,13 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import vuePlugin from 'eslint-plugin-vue'
 
 import { codeStyle } from './codeStyle.ts'
 import { GLOB_FILES_VUE } from '../globs.ts'
-
-import vuePlugin from 'eslint-plugin-vue'
 
 const stylisticRules = codeStyle({
 	isLibrary: false,

--- a/lib/configs/vue2.ts
+++ b/lib/configs/vue2.ts
@@ -2,14 +2,14 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import vuePlugin from 'eslint-plugin-vue'
 
 import { vue } from './vue.ts'
 import { GLOB_FILES_VUE } from '../globs.ts'
 import { restrictConfigFiles } from '../utils.ts'
-
-import vuePlugin from 'eslint-plugin-vue'
 
 /**
  * Vue2 related ESLint rules for Nextcloud

--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -2,14 +2,14 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import vuePlugin from 'eslint-plugin-vue'
 
 import { vue } from './vue.ts'
 import { GLOB_FILES_VUE } from '../globs.ts'
 import { restrictConfigFiles } from '../utils.ts'
-
-import vuePlugin from 'eslint-plugin-vue'
 
 /**
  * Vue3 related ESLint rules for Nextcloud

--- a/lib/plugins/nextcloud/rules/index.ts
+++ b/lib/plugins/nextcloud/rules/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Rule } from 'eslint'
+
 import noDeprecations from './no-deprecations.ts'
 import noRemovedApis from './no-removed-apis.ts'
 

--- a/lib/plugins/nextcloud/rules/no-removed-apis.ts
+++ b/lib/plugins/nextcloud/rules/no-removed-apis.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Rule, Scope } from 'eslint'
+
 import { createVersionValidator } from '../utils/version-parser.ts'
 
 // ------------------------------------------------------------------------------

--- a/lib/plugins/nextcloud/utils/version-parser.test.ts
+++ b/lib/plugins/nextcloud/utils/version-parser.test.ts
@@ -9,11 +9,11 @@ import { join } from 'node:path'
 import { afterAll, afterEach, beforeAll, describe, expect, it, test, vi } from 'vitest'
 
 import {
+	createVersionValidator,
+	findAppinfo,
 	isDirectory,
 	isFile,
 	sanitizeTargetVersion,
-	findAppinfo,
-	createVersionValidator,
 } from './version-parser.ts'
 
 vi.mock('node:fs', () => fs)

--- a/lib/plugins/nextcloud/utils/version-parser.ts
+++ b/lib/plugins/nextcloud/utils/version-parser.ts
@@ -7,8 +7,8 @@ import type { Rule } from 'eslint'
 
 import { XMLParser } from 'fast-xml-parser'
 import { lstatSync, readFileSync } from 'node:fs'
-import { sep, resolve, isAbsolute, dirname } from 'node:path'
-import { valid, lte } from 'semver'
+import { dirname, isAbsolute, resolve, sep } from 'node:path'
+import { lte, valid } from 'semver'
 
 /**
  * Check if a given path exists and is a directory

--- a/tests/config-codestyle.test.ts
+++ b/tests/config-codestyle.test.ts
@@ -5,7 +5,7 @@
 import type { Linter } from 'eslint'
 
 import { ESLint } from 'eslint'
-import * as path from 'path'
+import { join, resolve } from 'path'
 import { expect, test } from 'vitest'
 
 import * as eslintConfig from '../lib/index.ts'
@@ -17,7 +17,7 @@ const eslint = new ESLint({
 })
 
 const lintFile = async (file) => {
-	const real = path.resolve(path.join(__dirname, file))
+	const real = resolve(join(__dirname, file))
 	return await eslint.lintFiles(real)
 }
 
@@ -25,6 +25,7 @@ test.for([
 	'array',
 	'arrow-function',
 	'function',
+	'imports',
 	'indention',
 	'objects',
 	'quotes',

--- a/tests/config-typescript.test.ts
+++ b/tests/config-typescript.test.ts
@@ -5,7 +5,7 @@
 import type { Linter } from 'eslint'
 
 import { ESLint } from 'eslint'
-import * as path from 'path'
+import { join, resolve } from 'path'
 import { describe, expect, test } from 'vitest'
 
 import * as eslintConfig from '../lib/index.ts'
@@ -17,7 +17,7 @@ const eslint = new ESLint({
 
 describe('Typescript', () => {
 	async function lintFile(file: string) {
-		const real = path.resolve(path.join(__dirname, file))
+		const real = resolve(join(__dirname, file))
 		return await eslint.lintFiles(real)
 	}
 

--- a/tests/fixtures/codestyle/input/imports.ts
+++ b/tests/fixtures/codestyle/input/imports.ts
@@ -1,0 +1,8 @@
+import type Foo from 'foo'
+import MyComponent from '../components/MyComponent.vue'
+import { b, a } from 'foo'
+import { resolve } from 'path'
+import type { basename } from 'path'
+import AClass from '../class.ts'
+import Bar from 'a-package'
+import IconCheck from 'vue-material-design-icons/Check.vue'

--- a/tests/fixtures/codestyle/output/imports.ts
+++ b/tests/fixtures/codestyle/output/imports.ts
@@ -1,0 +1,11 @@
+import type Foo from 'foo'
+import type { basename } from 'path'
+
+import Bar from 'a-package'
+import { a, b } from 'foo'
+import { resolve } from 'path'
+
+import MyComponent from '../components/MyComponent.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
+
+import AClass from '../class.ts'


### PR DESCRIPTION
* Chained on https://github.com/nextcloud-libraries/eslint-config/pull/973

Similar to how Talk is sorting without the special handling of `material-design-icons` (a bit random to share this in the config).