### PR TITLE
feat: add import and export rules

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -5,13 +5,12 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
+import stylistic from '@stylistic/eslint-plugin'
 import {
 	GLOB_FILES_JAVASCRIPT,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
-
-import stylistic from '@stylistic/eslint-plugin'
 import l10nPlugin from '../plugins/l10n/index.ts'
 
 /**

--- a/lib/configs/documentation.ts
+++ b/lib/configs/documentation.ts
@@ -5,13 +5,13 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
+import jsdocPlugin from 'eslint-plugin-jsdoc'
 import {
 	GLOB_FILES_JAVASCRIPT,
 	GLOB_FILES_TESTING,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
-import jsdocPlugin from 'eslint-plugin-jsdoc'
 
 /**
  * Config factory for code documentation related rules (JSDoc)

--- a/lib/configs/imports.ts
+++ b/lib/configs/imports.ts
@@ -1,0 +1,116 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { ConfigOptions } from '../types.d.ts'
+import type { Linter } from 'eslint'
+
+import perfectionist from 'eslint-plugin-perfectionist'
+
+import {
+	GLOB_FILES_JAVASCRIPT,
+	GLOB_FILES_TYPESCRIPT,
+	GLOB_FILES_VUE,
+} from '../globs.ts'
+
+/**
+ * Generate imports and exports related ESLint rules.
+ *
+ * @param options - Configuration options
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function imports(options: ConfigOptions): Linter.Config[] {
+	return [
+		{
+			name: 'nextcloud/imports/setup',
+			plugins: {
+				perfectionist,
+			},
+		},
+		{
+			name: 'nextcloud/imports/rules',
+			files: [
+				...GLOB_FILES_JAVASCRIPT,
+				...GLOB_FILES_TYPESCRIPT,
+				...GLOB_FILES_VUE,
+			],
+			rules: {
+				// Require file extensions
+				'no-restricted-imports': [
+					'error',
+					{
+						patterns: [
+							{
+								regex: '^(\\.*)/(.+/)*[^/.]+$',
+								message: 'Import is missing the file extension.',
+							},
+						],
+					},
+				],
+				// Sorting of imports
+				'sort-imports': 'off',
+				'perfectionist/sort-imports': [
+					'error',
+					{
+						type: 'natural',
+						newlinesBetween: 'ignore',
+						groups: [
+							// type first
+							'type',
+							{ newlinesBetween: 'always' },
+							// external things
+							[
+								'builtin',
+								'external',
+								'object',
+							],
+							// everything else which is everything internal
+							'unknown',
+							// import style from 'my.module.css'
+							'style',
+							// Vue components
+							'vue',
+							// side effect only: import 'sideeffect.js'
+							'side-effect',
+						],
+						customGroups: {
+							value: {
+								vue: '\\.vue$',
+							},
+						},
+					},
+				],
+				'perfectionist/sort-named-exports': [
+					'error',
+					createSortingConfig('export'),
+				],
+				'perfectionist/sort-named-imports': [
+					'error',
+					createSortingConfig('import'),
+				],
+			},
+		},
+	]
+}
+
+/**
+ * Create the same rule config for exports and import.
+ *
+ * @param type The type for which to create the config
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function createSortingConfig(type: 'export' | 'import') {
+	return {
+		type: 'natural',
+		groupKind: 'types-first',
+
+		/* eslint-disable @stylistic/no-tabs */
+		// TODO: use when 4.12.0+ is released
+		// newlinesBetween: 'always',
+		// partitionByNewLine: false,
+		// groups: [
+		// 	`type-${type}`,
+		// 	[`value-${type}`, 'unknown'],
+		// ],
+	}
+}

--- a/lib/configs/javascript.ts
+++ b/lib/configs/javascript.ts
@@ -5,15 +5,14 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
+import eslintRules from '@eslint/js'
+import globals from 'globals'
 import {
 	GLOB_FILES_JAVASCRIPT,
 	GLOB_FILES_TESTING,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
-
-import eslintRules from '@eslint/js'
-import globals from 'globals'
 import nextcloudPlugin from '../plugins/nextcloud/index.ts'
 
 /**

--- a/lib/configs/json.ts
+++ b/lib/configs/json.ts
@@ -4,13 +4,12 @@
  */
 import type { ESLint, Linter } from 'eslint'
 
+import jsonPlugin from '@eslint/json'
 import {
 	GLOB_FILES_JSON,
 	GLOB_FILES_JSONC,
 	GLOB_FILES_MS_JSON,
 } from '../globs.ts'
-
-import jsonPlugin from '@eslint/json'
 import packageJsonPlugin from '../plugins/packageJson.ts'
 
 /**

--- a/lib/configs/node.ts
+++ b/lib/configs/node.ts
@@ -4,8 +4,8 @@
  */
 import type { Linter } from 'eslint'
 
-import { GLOB_FILES_TESTING } from '../globs.ts'
 import globals from 'globals'
+import { GLOB_FILES_TESTING } from '../globs.ts'
 
 /**
  * Config setup for the node environment.

--- a/lib/configs/typescript.ts
+++ b/lib/configs/typescript.ts
@@ -5,14 +5,13 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
+import typescriptPlugin from 'typescript-eslint'
 import {
 	GLOB_FILES_TESTING,
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
 import { restrictConfigFiles } from '../utils.ts'
-
-import typescriptPlugin from 'typescript-eslint'
 
 /**
  * Typescript related ESLint rules for Nextcloud

--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -5,10 +5,9 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
-import { codeStyle } from './codeStyle.ts'
-import { GLOB_FILES_VUE } from '../globs.ts'
-
 import vuePlugin from 'eslint-plugin-vue'
+import { GLOB_FILES_VUE } from '../globs.ts'
+import { codeStyle } from './codeStyle.ts'
 
 const stylisticRules = codeStyle({
 	isLibrary: false,

--- a/lib/configs/vue2.ts
+++ b/lib/configs/vue2.ts
@@ -5,11 +5,10 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
-import { vue } from './vue.ts'
+import vuePlugin from 'eslint-plugin-vue'
 import { GLOB_FILES_VUE } from '../globs.ts'
 import { restrictConfigFiles } from '../utils.ts'
-
-import vuePlugin from 'eslint-plugin-vue'
+import { vue } from './vue.ts'
 
 /**
  * Vue2 related ESLint rules for Nextcloud

--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -5,11 +5,10 @@
 import type { Linter } from 'eslint'
 import type { ConfigOptions } from '../types.d.ts'
 
-import { vue } from './vue.ts'
+import vuePlugin from 'eslint-plugin-vue'
 import { GLOB_FILES_VUE } from '../globs.ts'
 import { restrictConfigFiles } from '../utils.ts'
-
-import vuePlugin from 'eslint-plugin-vue'
+import { vue } from './vue.ts'
 
 /**
  * Vue3 related ESLint rules for Nextcloud

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,7 @@ import type { ConfigOptions } from './types.d.ts'
 import { codeStyle } from './configs/codeStyle.ts'
 import { documentation } from './configs/documentation.ts'
 import { filesystem } from './configs/filesystem.ts'
+import { imports } from './configs/imports.ts'
 import { javascript } from './configs/javascript.ts'
 import { json } from './configs/json.ts'
 import { node } from './configs/node.ts'
@@ -87,6 +88,7 @@ function createConfig(options: ConfigOptions & { vue2?: boolean }) {
 				: vue3(options)
 		),
 		...documentation(options),
+		...imports(options),
 		...codeStyle(options),
 	]
 }

--- a/lib/plugins/l10n/rules/enforce-ellipsis.test.ts
+++ b/lib/plugins/l10n/rules/enforce-ellipsis.test.ts
@@ -4,7 +4,6 @@
  */
 import { RuleTester } from 'eslint'
 import { test } from 'vitest'
-
 import rule from './enforce-ellipsis.ts'
 
 test('rule: enforce-ellipsis', () => {

--- a/lib/plugins/l10n/rules/non-breaking-space.test.ts
+++ b/lib/plugins/l10n/rules/non-breaking-space.test.ts
@@ -5,7 +5,6 @@
 /* eslint-disable @nextcloud-l10n/non-breaking-space */
 import { RuleTester } from 'eslint'
 import { test } from 'vitest'
-
 import rule from './non-breaking-space.ts'
 
 test('rule: non-breaking-space', () => {

--- a/lib/plugins/nextcloud/index.ts
+++ b/lib/plugins/nextcloud/index.ts
@@ -4,8 +4,8 @@
  */
 import type { ESLint } from 'eslint'
 
-import { rules } from './rules/index.ts'
 import { packageVersion } from '../../version.ts'
+import { rules } from './rules/index.ts'
 
 export default {
 	rules,

--- a/lib/plugins/nextcloud/rules/index.ts
+++ b/lib/plugins/nextcloud/rules/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Rule } from 'eslint'
+
 import noDeprecations from './no-deprecations.ts'
 import noRemovedApis from './no-removed-apis.ts'
 

--- a/lib/plugins/nextcloud/rules/no-deprecations.test.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecations.test.ts
@@ -4,7 +4,6 @@
  */
 import { RuleTester } from 'eslint'
 import { describe, test } from 'vitest'
-
 import rule from './no-deprecations.ts'
 
 // ------------------------------------------------------------------------------

--- a/lib/plugins/nextcloud/rules/no-removed-apis.test.ts
+++ b/lib/plugins/nextcloud/rules/no-removed-apis.test.ts
@@ -4,7 +4,6 @@
  */
 import { RuleTester } from 'eslint'
 import { describe, test } from 'vitest'
-
 import rule from './no-removed-apis.ts'
 
 // ------------------------------------------------------------------------------

--- a/lib/plugins/nextcloud/rules/no-removed-apis.ts
+++ b/lib/plugins/nextcloud/rules/no-removed-apis.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Rule, Scope } from 'eslint'
+
 import { createVersionValidator } from '../utils/version-parser.ts'
 
 // ------------------------------------------------------------------------------

--- a/lib/plugins/nextcloud/utils/version-parser.test.ts
+++ b/lib/plugins/nextcloud/utils/version-parser.test.ts
@@ -7,13 +7,12 @@ import type { Rule } from 'eslint'
 import { fs, vol } from 'memfs'
 import { join } from 'node:path'
 import { afterAll, afterEach, beforeAll, describe, expect, it, test, vi } from 'vitest'
-
 import {
+	createVersionValidator,
+	findAppinfo,
 	isDirectory,
 	isFile,
 	sanitizeTargetVersion,
-	findAppinfo,
-	createVersionValidator,
 } from './version-parser.ts'
 
 vi.mock('node:fs', () => fs)

--- a/lib/plugins/nextcloud/utils/version-parser.ts
+++ b/lib/plugins/nextcloud/utils/version-parser.ts
@@ -2,13 +2,14 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { PluginOption } from '../plugin.d.ts'
+
 import type { Rule } from 'eslint'
+import type { PluginOption } from '../plugin.d.ts'
 
 import { XMLParser } from 'fast-xml-parser'
 import { lstatSync, readFileSync } from 'node:fs'
-import { sep, resolve, isAbsolute, dirname } from 'node:path'
-import { valid, lte } from 'semver'
+import { dirname, isAbsolute, resolve, sep } from 'node:path'
+import { lte, valid } from 'semver'
 
 /**
  * Check if a given path exists and is a directory

--- a/lib/plugins/packageJson.ts
+++ b/lib/plugins/packageJson.ts
@@ -7,7 +7,6 @@ import type { ESLint, Rule } from 'eslint'
 
 import path from 'node:path'
 import sortPackageJson from 'sort-package-json'
-
 import { packageVersion } from '../version.ts'
 
 const SortPackageJsonRule: Rule.RuleModule = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/json": "^0.12.0",
         "@stylistic/eslint-plugin": "^4.2.0",
         "eslint-plugin-jsdoc": "^50.6.10",
+        "eslint-plugin-perfectionist": "^4.12.2",
         "eslint-plugin-vue": "^10.0.0",
         "fast-xml-parser": "^5.2.1",
         "globals": "^16.0.0",
@@ -1830,6 +1831,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-plugin-perfectionist": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.12.2.tgz",
+      "integrity": "sha512-OWh3y2c7oMNEbyk8BmcQgMil13FAMViQbycV04TNztf6YSheOtbagcpwJkc3aZt6lYDyL0zpY/aPjwi7fxT+5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.31.0",
+        "@typescript-eslint/utils": "^8.31.0",
+        "natural-orderby": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.45.0"
+      }
+    },
     "node_modules/eslint-plugin-vue": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.0.0.tgz",
@@ -2544,6 +2562,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "node_modules/natural-orderby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
+      "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@eslint/json": "^0.12.0",
     "@stylistic/eslint-plugin": "^4.2.0",
     "eslint-plugin-jsdoc": "^50.6.10",
+    "eslint-plugin-perfectionist": "^4.12.2",
     "eslint-plugin-vue": "^10.0.0",
     "fast-xml-parser": "^5.2.1",
     "globals": "^16.0.0",

--- a/tests/config-codestyle.test.ts
+++ b/tests/config-codestyle.test.ts
@@ -5,8 +5,8 @@
 import type { Linter } from 'eslint'
 
 import { ESLint } from 'eslint'
+import { join, resolve } from 'path'
 import { expect, test } from 'vitest'
-import * as path from 'path'
 import * as eslintConfig from '../lib/index.js'
 
 const eslint = new ESLint({
@@ -16,7 +16,7 @@ const eslint = new ESLint({
 })
 
 const lintFile = async (file) => {
-	const real = path.resolve(path.join(__dirname, file))
+	const real = resolve(join(__dirname, file))
 	return await eslint.lintFiles(real)
 }
 
@@ -24,6 +24,8 @@ test.for([
 	'array',
 	'arrow-function',
 	'function',
+	'exports',
+	'imports',
 	'indention',
 	'objects',
 	'quotes',

--- a/tests/config-javascript.test.ts
+++ b/tests/config-javascript.test.ts
@@ -5,11 +5,10 @@
 import type { Linter } from 'eslint'
 
 import { ESLint } from 'eslint'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
-
-import * as path from 'path'
-import * as eslintConfig from '../lib/index.js'
 import { access, copyFile, rm } from 'fs/promises'
+import { join, resolve } from 'path'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import * as eslintConfig from '../lib/index.js'
 
 const eslint = new ESLint({
 	overrideConfigFile: true,
@@ -17,7 +16,7 @@ const eslint = new ESLint({
 })
 
 const lintFile = async (file) => {
-	const real = path.resolve(path.join(__dirname, file))
+	const real = resolve(join(__dirname, file))
 	return await eslint.lintFiles(real)
 }
 
@@ -70,12 +69,12 @@ test('allows JSDoc syntax', async () => {
 
 describe('no-use-before-define', () => {
 	beforeAll(async () => {
-		const fixture = path.resolve(path.join(__dirname, 'fixtures/use-before-define.ts'))
+		const fixture = resolve(join(__dirname, 'fixtures/use-before-define.ts'))
 		await copyFile(fixture, fixture.replace(/\.ts$/, '.js'))
 	})
 
 	afterAll(async () => {
-		const fixture = path.resolve(path.join(__dirname, 'fixtures/use-before-define.ts'))
+		const fixture = resolve(join(__dirname, 'fixtures/use-before-define.ts'))
 			.replace(/\.ts$/, '.js')
 
 		try {

--- a/tests/config-typescript.test.ts
+++ b/tests/config-typescript.test.ts
@@ -5,8 +5,8 @@
 import type { Linter } from 'eslint'
 
 import { ESLint } from 'eslint'
+import { join, resolve } from 'path'
 import { describe, expect, test } from 'vitest'
-import * as path from 'path'
 import * as eslintConfig from '../lib/index.js'
 
 const eslint = new ESLint({
@@ -16,7 +16,7 @@ const eslint = new ESLint({
 
 describe('Typescript', () => {
 	async function lintFile(file: string) {
-		const real = path.resolve(path.join(__dirname, file))
+		const real = resolve(join(__dirname, file))
 		return await eslint.lintFiles(real)
 	}
 

--- a/tests/fixtures/codestyle/input/exports.ts
+++ b/tests/fixtures/codestyle/input/exports.ts
@@ -1,0 +1,13 @@
+export {
+	zbar,
+	type a,
+	afoo,
+} from './my/module.ts'
+
+const z = ''
+const b = ''
+
+export {
+	z,
+	b,
+}

--- a/tests/fixtures/codestyle/input/imports.ts
+++ b/tests/fixtures/codestyle/input/imports.ts
@@ -1,0 +1,23 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+
+import type { NcSelectOption } from '../composables/useNcSelectModel.ts'
+import type { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+
+import NcButton from '@nextcloud/vue/components/NcButton'
+import type { ButtonVariant } from '@nextcloud/vue/components/NcButton'
+import { z, a, y } from '../../../constants.js'
+import { useAppConfigStore } from './appConfig.store.ts'
+
+import SettingsFormGroup from './components/SettingsFormGroup.vue'
+import IconBellRingOutline from 'vue-material-design-icons/BellRingOutline.vue'
+import 'some-sideeffect'
+
+import type { AssertPredicate } from 'node:assert'
+import style from './my.module.css'

--- a/tests/fixtures/codestyle/output/exports.ts
+++ b/tests/fixtures/codestyle/output/exports.ts
@@ -1,0 +1,14 @@
+export {
+	type a,
+
+	afoo,
+	zbar,
+} from './my/module.ts'
+
+const z = ''
+const b = ''
+
+export {
+	b,
+	z,
+}

--- a/tests/fixtures/codestyle/output/imports.ts
+++ b/tests/fixtures/codestyle/output/imports.ts
@@ -1,0 +1,21 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ButtonVariant } from '@nextcloud/vue/components/NcButton'
+import type { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import type { AssertPredicate } from 'node:assert'
+import type { NcSelectOption } from '../composables/useNcSelectModel.ts'
+
+import { t } from '@nextcloud/l10n'
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+import { a, y, z } from '../../../constants.js'
+import { useAppConfigStore } from './appConfig.store.ts'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import IconBellRingOutline from 'vue-material-design-icons/BellRingOutline.vue'
+import SettingsFormGroup from './components/SettingsFormGroup.vue'
+
+import 'some-sideeffect'
+import style from './my.module.css'

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { ESLint, Linter } from 'eslint'
+
 import { expect } from 'vitest'
 
 /**


### PR DESCRIPTION
* faster alternative for https://github.com/nextcloud-libraries/eslint-config/pull/973

- Enforce file extensions
- Enforce consistent named import / export sorting
- Enforce consistent module sorting

Do not use eslint-plugin-import(-x) because it is quite slow and has many issues with parsing different formats like vue script-setup in Typescript and similar.