### PR TITLE
fix: require node ^20.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": ">=9"
   },
   "engines": {
-    "node": "^20.10 || ^22"
+    "node": "^20.19 || ^22"
   },
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
Node <20.19 results in an error between in vue-eslint-plugin from stylistic resolving.