### PR TITLE
fix(typescript): remove `@typescript-eslint/no-shadow`

### DIFF
--- a/lib/configs/typescript.ts
+++ b/lib/configs/typescript.ts
@@ -56,9 +56,6 @@ export function typescript(options: ConfigOptions): Linter.Config[] {
 						functions: false,
 					},
 				],
-				// Do not shadow outer variables / functions - this can lead to wrong assumptions
-				'no-shadow': 'off',
-				'@typescript-eslint/no-shadow': 'error',
 			},
 		},
 


### PR DESCRIPTION
- Fix: https://github.com/nextcloud-libraries/eslint-config/issues/978
- IMO, when there is an error from a shadow variable, it is usually visible during testing
- In other cases, it requires renaming "default" names such as `state` in Vuex, `event`, `callback`, `error` even when they aren't really used
  - Not auto-fixable
- Also, it adds inconsistency in JS/TS, as this rule is only enabled in TS