### PR TITLE
fix(documentation): do not remove JSDoc types in Vue JS files

### DIFF
--- a/tests/config-typescript.test.ts
+++ b/tests/config-typescript.test.ts
@@ -20,18 +20,40 @@ describe('Typescript', () => {
 		return await eslint.lintFiles(real)
 	}
 
-	test('works with Typescript + Vue', async () => {
-		const results = await lintFile('fixtures/typescript-test.vue')
-		expect(results).toHaveIssueCount(0)
-	})
+	// Vue files can be both Javascript and Typescript
+	describe('Vue', () => {
+		test('works with Typescript + Vue', async () => {
+			const results = await lintFile('fixtures/typescript-test.vue')
+			expect(results).toHaveIssueCount(0)
+		})
 
-	test('overrides have higher priority than vue', async () => {
-		const results = await lintFile('fixtures/typescript-vue-overrides.vue')
-		expect(results).toHaveIssueCount(1)
-		// Expect "'@type' is redundant when using a type system."
-		expect(results).toHaveIssue({
-			ruleId: 'jsdoc/check-tag-names',
-			line: 15,
+		test('overrides have higher priority than vue', async () => {
+			const results = await lintFile('fixtures/typescript-vue-overrides.vue')
+			// In Javascript rules this rule is no-use-before-define, not @typescript-eslint/no-use-before-define
+			expect(results).toHaveIssueCount(1)
+			expect(results).toHaveIssue('@typescript-eslint/no-use-before-define')
+		})
+
+		test('with lang="ts" does not require types in JSDoc', async () => {
+			const results = await lintFile('fixtures/JsdocTypescriptWithoutTypes.vue')
+			expect(results).toHaveIssueCount(0)
+		})
+
+		test('without lang="ts" requires types in JSDoc like in Javascript files', async () => {
+			const results = await lintFile('fixtures/JsdocJavascriptWithoutTypes.vue')
+			expect(results).toHaveIssueCount(20)
+			expect(results).toHaveIssue('jsdoc/require-param-type')
+		})
+
+		test('with lang="ts" does not allow types in JSDoc', async () => {
+			const results = await lintFile('fixtures/JsdocTypescriptWithTypes.vue')
+			expect(results).toHaveIssueCount(24)
+			expect(results).toHaveIssue('jsdoc/no-types')
+		})
+
+		test('without lang="ts" allows types in JSDoc like in Javascript files', async () => {
+			const results = await lintFile('fixtures/JsdocJavascriptWithTypes.vue')
+			expect(results).toHaveIssueCount(0)
 		})
 	})
 

--- a/tests/fixtures/JsdocJavascriptWithTypes.vue
+++ b/tests/fixtures/JsdocJavascriptWithTypes.vue
@@ -1,0 +1,80 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script>
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// This is a valid .vue file in JavaScript
+// With required types in JSDocs
+// Types are required even in TypeScript projects
+
+/**
+ * @typedef Foo
+ * @property {string} bar - Bar
+ */
+
+/**
+ * @param {Foo} foo - Foo
+ * @param {number} n - Number
+ * @return {void} Returns nothing
+ */
+function log1(foo, n) {}
+
+/**
+ * @param {Foo} foo - Foo
+ * @param {number} n - Number
+ * @return {void} Returns nothing
+ */
+const log2 = (foo, n) => {}
+
+/**
+ * @param {Foo} foo - Foo
+ * @param {number} n - Number
+ * @return {void} Returns nothing
+ */
+const log3 = function(foo, n) {}
+
+const obj = {
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 * @return {void} Returns nothing
+	 */
+	log4(foo, n) {},
+}
+
+class Log {
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 * @return {void} Returns nothing
+	 */
+	log5(foo, n) {}
+
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 * @return {void} Returns nothing
+	 */
+	static log6(foo, n) {}
+
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 */
+	constructor(foo, n) {}
+}
+
+/**
+ * @return {number} Just 42
+ */
+function log6() {
+	return 42
+}
+
+export default {
+	name: 'JsdocJavascriptWithTypes',
+}
+</script>

--- a/tests/fixtures/JsdocJavascriptWithoutTypes.vue
+++ b/tests/fixtures/JsdocJavascriptWithoutTypes.vue
@@ -1,0 +1,80 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script>
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable jsdoc/require-returns-check */
+
+// This is a .vue file in JavaScript
+// Missing required types in JSDocs
+// Types are required even in TypeScript projects
+
+/**
+ * bar - Bar
+ */
+
+/**
+ * @param foo - Foo
+ * @param n - Number
+ * @return Returns nothing
+ */
+function log1(foo, n) {}
+
+/**
+ * @param foo - Foo
+ * @param n - Number
+ * @return Returns nothing
+ */
+const log2 = (foo, n) => {}
+
+/**
+ * @param foo - Foo
+ * @param n - Number
+ * @return Returns nothing
+ */
+const log3 = function(foo, n) {}
+
+const obj = {
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 * @return Returns nothing
+	 */
+	log4(foo, n) {},
+}
+
+class Log {
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 * @return Returns nothing
+	 */
+	log5(foo, n) {}
+
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 * @return Returns nothing
+	 */
+	static log6(foo, n) {}
+
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 */
+	constructor(foo, n) {}
+}
+
+/**
+ * @return Just 42
+ */
+function log6() {
+	return 42
+}
+
+export default {
+	name: 'JsdocJavascriptWithoutTypes',
+}
+</script>

--- a/tests/fixtures/JsdocTypescriptWithTypes.vue
+++ b/tests/fixtures/JsdocTypescriptWithTypes.vue
@@ -1,0 +1,72 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+type Foo = {
+	/**
+	 * Bar
+	 */
+	bar: string
+}
+
+/**
+ * @param {Foo} foo - Foo
+ * @param {number} n - Number
+ * @return {void} Returns nothing
+ */
+function log1(foo: Foo, n: number): void {}
+
+/**
+ * @param {Foo} foo - Foo
+ * @param {number} n - Number
+ * @return {void} Returns nothing
+ */
+const log2 = (foo: Foo, n: number): void => {}
+
+/**
+ * @param {Foo} foo - Foo
+ * @param {number} n - Number
+ * @return {void} Returns nothing
+ */
+const log3 = function(foo: Foo, n: number): void {}
+
+const obj = {
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 * @return {void} Returns nothing
+	 */
+	log4(foo: Foo, n: number): void {},
+}
+
+class Log {
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 * @return {void} Returns nothing
+	 */
+	log5(foo: Foo, n: number): void {}
+
+	/**
+	 * @param {Foo} foo - Foo
+	 * @param {number} n - Number
+	 * @return {void} Returns nothing
+	 */
+	static log6(foo: Foo, n: number): void {}
+}
+
+/**
+ * @return {number} Just 42
+ */
+function log6() {
+	return 42
+}
+
+export default {
+	name: 'JsdocTypescriptWithTypes',
+}
+</script>

--- a/tests/fixtures/JsdocTypescriptWithoutTypes.vue
+++ b/tests/fixtures/JsdocTypescriptWithoutTypes.vue
@@ -1,0 +1,79 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable jsdoc/require-returns-check */
+
+type Foo = {
+	/**
+	 * Bar
+	 */
+	bar: string
+}
+
+/**
+ * @param foo - Foo
+ * @param n - Number
+ * @return Returns nothing
+ */
+function log1(foo: Foo, n: number): void {}
+
+/**
+ * @param foo - Foo
+ * @param n - Number
+ * @return Returns nothing
+ */
+const log2 = (foo: Foo, n: number): void => {}
+
+/**
+ * @param foo - Foo
+ * @param n - Number
+ * @return Returns nothing
+ */
+const log3 = function(foo: Foo, n: number): void {}
+
+const obj = {
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 * @return Returns nothing
+	 */
+	log4(foo: Foo, n: number): void {},
+}
+
+class Log {
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 * @return Returns nothing
+	 */
+	log5(foo: Foo, n: number): void {}
+
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 * @return Returns nothing
+	 */
+	static log6(foo: Foo, n: number): void {}
+
+	/**
+	 * @param foo - Foo
+	 * @param n - Number
+	 */
+	constructor(foo: Foo, n: number) {}
+}
+
+/**
+ * @return Just 42
+ */
+function log6() {
+	return 42
+}
+
+export default {
+	name: 'JsdocTypescriptWithoutTypes',
+}
+</script>

--- a/tests/fixtures/typescript-vue-overrides.vue
+++ b/tests/fixtures/typescript-vue-overrides.vue
@@ -9,10 +9,6 @@
 </template>
 
 <script lang="ts" setup>
-/**
- * This will result in no error on JS but one in TS as type is duplicated
- *
- * @type {string}
- */
-const foo: string = 'Foo bar'
+const foo = 'Foo ' + bar
+const bar = 'Bar'
 </script>


### PR DESCRIPTION
- Fix: https://github.com/nextcloud-libraries/eslint-config/issues/980
- Currently `npm run lint` breaks many Vue + JS files if TS config is used

## Half-working solution

- `jsdoc/require-property-type` makes no harm in TS, there are no `@property`
- In `.vue` files (that can be both TS and JS):
  - Use `jsdoc/no-types` only if there are TS types
  - Use `jsdoc/require-param-type` only if there are no TS types
  - Disable `jsdoc/require-returns-type` (because a return type is often inferred, not specified) 
  - Allow type-tags in `jsdoc/check-tag-names` (because it can be used in a JS component)

So it **doesn't break** existing JS components (like before).
But it applies only ~half of JSDoc + TS rules in TS components.

## Alternative

Generate `files` on the fly by checking `<script lang>` to distinguish between JS and TS Vue files.