### PR TITLE
fix(codeStyle): allow devs write small objects in one line

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -117,7 +117,10 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 						multiline: true,
 					},
 				],
-				'@stylistic/object-property-newline': 'error',
+				'@stylistic/object-property-newline': [
+					'error',
+					{ allowAllPropertiesOnSameLine: true },
+				],
 
 				// No space between function name and parenthesis. Enforce fn() instead of fn ()
 				'@stylistic/function-call-spacing': [

--- a/tests/fixtures/codestyle/input/objects.js
+++ b/tests/fixtures/codestyle/input/objects.js
@@ -14,7 +14,7 @@ const obj2 = {
 // Require spaces around braces
 const obj3 = {first: 1}
 
-// Prefer multi line objects
+// Allow all properties in one line
 const obj4 = { first: 1, second: 'two' }
 
 // Use trailing commas to be git diff friendly

--- a/tests/fixtures/codestyle/output/objects.js
+++ b/tests/fixtures/codestyle/output/objects.js
@@ -14,11 +14,8 @@ const obj2 = {
 // Require spaces around braces
 const obj3 = { first: 1 }
 
-// Prefer multi line objects
-const obj4 = {
-	first: 1,
-	second: 'two',
-}
+// Allow all properties in one line
+const obj4 = { first: 1, second: 'two' }
 
 // Use trailing commas to be git diff friendly
 const obj5 = {


### PR DESCRIPTION
- Fix: https://github.com/nextcloud-libraries/eslint-config/issues/979

While it makes sense for large objects, requiring even small objects like `{ width, height }` be defined in 3+ lines.

I'd prefer to let developers decide when it is better.

```ts
function getPos(): { x: number, y: number } {
  //
}

// vs

function getPos(): { 
  x: number,
  y: number,
} {
  //
}
```

```ts
const { width, height } = getSize()

// vs

const { 
  width,
  height
} = getSize()
```

```ts
emit('app:config:change', { key, value })

// vs

emit('app:config:change', {
  key,
  value,
})
```