### PR TITLE
fix(codeStyle): allow single line arrays

### DIFF
--- a/lib/configs/codeStyle.ts
+++ b/lib/configs/codeStyle.ts
@@ -98,17 +98,8 @@ export function codeStyle(options: ConfigOptions): (Linter.Config | Linter.BaseC
 						minItems: null, // disable
 					},
 				],
-				// Enforce new lines between array elements (better git diff) but allow to have single line arrays for array parameters
-				'@stylistic/array-element-newline': [
-					'error',
-					{
-						ArrayExpression: 'always',
-						ArrayPattern: {
-							consistent: true,
-							multiline: true,
-						},
-					},
-				],
+				// Enforce new lines between array elements (better git diff) but allow to have single line arrays
+				'@stylistic/array-element-newline': ['error', 'consistent'],
 				// Same for objects as for arrays
 				'@stylistic/object-curly-newline': [
 					'error',

--- a/tests/fixtures/codestyle/input/array.js
+++ b/tests/fixtures/codestyle/input/array.js
@@ -1,8 +1,15 @@
-// this should be multi line
-const arr = ['first', 'second', 'third', 'and', 'so', 'on']
+// This can be a single line
+const arr = ['first', 'second']
 
-// this has a missing trailing comma causing too much git diff
+// This is not a single line already and should be one element per line
 const arr2 = [
+	'first', 'second',
+	'third', 'and',
+	'so', 'on'
+]
+
+// This has a missing trailing comma causing too much git diff
+const arr3 = [
 	'first',
 	'second',
 	'third'

--- a/tests/fixtures/codestyle/output/array.js
+++ b/tests/fixtures/codestyle/output/array.js
@@ -1,5 +1,8 @@
-// this should be multi line
-const arr = [
+// This can be a single line
+const arr = ['first', 'second']
+
+// This is not a single line already and should be one element per line
+const arr2 = [
 	'first',
 	'second',
 	'third',
@@ -8,8 +11,8 @@ const arr = [
 	'on',
 ]
 
-// this has a missing trailing comma causing too much git diff
-const arr2 = [
+// This has a missing trailing comma causing too much git diff
+const arr3 = [
 	'first',
 	'second',
 	'third',


### PR DESCRIPTION
- Fix: https://github.com/nextcloud-libraries/eslint-config/issues/979
- Same as https://github.com/nextcloud-libraries/eslint-config/pull/996

Allow developers to decide when a single-line array is fine.