### PR TITLE
feat(vue): add `vue/no-useless-v-bind` rule

### DIFF
--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -99,6 +99,8 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 				// Component names should match their export names - readability and maintainability ("where does this component come from?")
 				'vue/match-component-import-name': 'error',
 				'vue/match-component-file-name': 'error',
+				// prevent useless v-bind like `<foo :bar="'bar'"/>`
+				'vue/no-useless-v-bind': 'error',
 				// Warn on undefined components - we need this on warning level as long as people use mixins (then we can move to error)
 				'vue/no-undef-components': [
 					'warn',


### PR DESCRIPTION
This disallows e.g. `<foo :bar="'bar'" />` as this is basically `<foo bar="bar" />`.