### PR TITLE
feat(vue3): add script-setup releated rules

### DIFF
--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -133,6 +133,19 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 				'vue/padding-line-between-blocks': 'error',
 				// Prefer separated static and dynamic class attributes
 				'vue/prefer-separate-static-class': 'error',
+				// For consistent layout of components
+				'vue/define-macros-order': [
+					'error', {
+						order: [
+							'defineOptions',
+							'defineModel',
+							'defineProps',
+							'defineEmits',
+							'defineSlots',
+							'defineExpose',
+						],
+					},
+				],
 			},
 			name: 'nextcloud/vue/stylistic-rules',
 		},

--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -28,8 +28,10 @@ export function vue3(options: ConfigOptions): Linter.Config[] {
 		{
 			files: GLOB_FILES_VUE,
 			rules: {
-			// Deprecated thus we should not use it
+				// Deprecated thus we should not use it
 				'vue/no-deprecated-delete-set': 'error',
+				// When using script-setup the modern approach should be used
+				'vue/prefer-define-options': 'error',
 			},
 			name: 'nextcloud/vue3/rules',
 		},


### PR DESCRIPTION
When using `<script setup>` we should directly use the modern approach using `defineOptions` also we should have a defined order so its easier to navigate in components.

@ShGKme as you are probably one of the heavy script-setup users, thats also the order in talk desktop right?