### PR TITLE
feat(vue): add `vue/prefer-separate-static-class` rule

### DIFF
--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -129,6 +129,8 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 				'vue/new-line-between-multi-line-property': 'error',
 				// Add consistent padding between blocks
 				'vue/padding-line-between-blocks': 'error',
+				// prefer separated static and dynamic class attributes
+				'vue/prefer-separate-static-class': 'error',
 			},
 			name: 'nextcloud/vue/stylistic-rules',
 		},


### PR DESCRIPTION
A more stylistic rule to enforce what we already soft-enforce (review based) on e.g. nextcloud-vue: Use separate static class attribute for plain class and dynamic class attribute if needed.