### PR TITLE
fix(no-deprecated-props): extend existing rules to support other components

### DIFF
--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
@@ -121,5 +121,85 @@ ruleTester.run('no-deprecated-props', rule, {
 			errors: [{ messageId: 'useVariantInstead' }],
 			output: '<template><NcButton v-show="!loading" variant="tertiary" @click="handle"><template #icon><IconDelete /></template></NcButton></template>',
 		},
+		{
+			code: '<template><NcActionButton aria-hidden @click="handle">Hello</NcActionButton></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'removeAriaHidden' }],
+		},
+		{
+			code: '<template><NcButton aria-hidden @click="handle">Hello</NcButton></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'removeAriaHidden' }],
+		},
+		{
+			code: '<template><NcActionButton :aria-hidden="true" @click="handle">Hello</NcActionButton></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'removeAriaHidden' }],
+		},
+		{
+			code: '<template><NcAppContent allow-swipe-navigation @click="handle">Hello</NcAppContent></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
+		},
+		{
+			code: '<template><NcAppContent :allow-swipe-navigation="false" @click="handle">Hello</NcAppContent></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
+		},
+		{
+			code: '<template><NcAvatar :show-user-status="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useHideStatusInstead' }],
+		},
+		{
+			code: '<template><NcAvatar :show-user-status-compact="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useVerboseStatusInstead' }],
+		},
+		{
+			code: '<template><NcAvatar :allow-placeholder="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useNoPlaceholderInstead' }],
+		},
+		{
+			code: '<template><NcDateTimePicker :formatter="customFormatter" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useFormatInstead' }],
+		},
+		{
+			code: '<template><NcDateTimePicker range /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useTypeDateRangeInstead' }],
+		},
+		{
+			code: '<template><NcDialog :can-close="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useNoCloseInstead' }],
+		},
+		{
+			code: '<template><NcModal :can-close="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useNoCloseInstead' }],
+		},
+		{
+			code: '<template><NcModal :enable-swipe="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useDisableSwipeForModalInstead' }],
+		},
+		{
+			code: '<template><NcPopover :focus-trap="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useNoFocusTrapInstead' }],
+		},
+		{
+			code: '<template><NcSelect :close-on-select="false" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useKeepOpenInstead' }],
+		},
+		{
+			code: '<template><NcSelect user-select /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useNcSelectUsersInstead' }],
+		},
 	],
 })

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
@@ -49,6 +49,30 @@ ruleTester.run('no-deprecated-props', rule, {
 			output: '<template><NcButton variant="primary">Hello</NcButton></template>',
 		},
 		{
+			code: '<template><NcActions type="primary">Hello</NcActions></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useVariantInstead' }],
+			output: '<template><NcActions variant="primary">Hello</NcActions></template>',
+		},
+		{
+			code: '<template><NcAppNavigationNew type="primary" text="Hello" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useVariantInstead' }],
+			output: '<template><NcAppNavigationNew variant="primary" text="Hello" /></template>',
+		},
+		{
+			code: '<template><NcChip type="primary" text="Hello" /></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useVariantInstead' }],
+			output: '<template><NcChip variant="primary" text="Hello" /></template>',
+		},
+		{
+			code: '<template><NcDialogButton type="primary">Hello</NcDialogButton></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useVariantInstead' }],
+			output: '<template><NcDialogButton variant="primary">Hello</NcDialogButton></template>',
+		},
+		{
 			code: '<template><NcButton type="tertiary">Hello</NcButton></template>',
 			filename: 'test.vue',
 			errors: [{ messageId: 'useVariantInstead' }],
@@ -65,6 +89,12 @@ ruleTester.run('no-deprecated-props', rule, {
 			filename: 'test.vue',
 			errors: [{ messageId: 'useTypeInstead' }],
 			output: '<template><NcButton type="button">Hello</NcButton></template>',
+		},
+		{
+			code: '<template><NcDialogButton native-type="button">Hello</NcDialogButton></template>',
+			filename: 'test.vue',
+			errors: [{ messageId: 'useTypeInstead' }],
+			output: '<template><NcDialogButton type="button">Hello</NcDialogButton></template>',
 		},
 		{
 			code: '<template><NcButton type="primary" native-type="button">Hello</NcButton></template>',

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
@@ -23,7 +23,17 @@ export default {
 		const legacyTypes = ['primary', 'error', 'warning', 'success', 'secondary', 'tertiary', 'tertiary-no-background']
 
 		return vueUtils.defineTemplateBodyVisitor(context, {
-			'VElement[name="ncbutton"] VAttribute:has(VIdentifier[name="type"])': function(node) {
+			'VElement VAttribute:has(VIdentifier[name="type"])': function(node) {
+				if (![
+					'ncactions',
+					'ncappnavigationnew',
+					'ncbutton',
+					'ncchip',
+					'ncdialogbutton',
+				].includes(node.parent.parent.name)) {
+					return
+				}
+
 				const hasNativeType = node.parent.attributes.find((attr) => (
 					attr.key.name === 'native-type'
 					|| (attr.key.type === 'VDirectiveKey' && attr.key.argument && attr.key.argument.name === 'native-type')))
@@ -55,7 +65,14 @@ export default {
 				}
 			},
 
-			'VElement[name="ncbutton"] VAttribute:has(VIdentifier[name="native-type"])': function(node) {
+			'VElement VAttribute:has(VIdentifier[name="native-type"])': function(node) {
+				if (![
+					'ncbutton',
+					'ncdialogbutton',
+				].includes(node.parent.parent.name)) {
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useTypeInstead',

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
@@ -16,6 +16,18 @@ export default {
 		messages: {
 			useTypeInstead: 'Using `native-type` for button variant is deprecated - use `type` instead.',
 			useVariantInstead: 'Using `type` for button variant is deprecated - use `variant` instead.',
+			useDisableSwipeForNavInstead: 'Using `allow-swipe-navigation` is deprecated - use `disable-swipe` instead',
+			useHideStatusInstead: 'Using `show-user-status` is deprecated - use `hide-status` instead',
+			useVerboseStatusInstead: 'Using `show-user-status-compact` is deprecated - use `verbose-status` instead',
+			useNoPlaceholderInstead: 'Using `allow-placeholder` is deprecated - use `no-placeholder` instead',
+			useFormatInstead: 'Using `formatter` is deprecated - use `format` instead',
+			useTypeDateRangeInstead: 'Using `range` is deprecated - use `type` with `date-range` or `datetime-range` instead',
+			useNoCloseInstead: 'Using `can-close` is deprecated - use `no-close` instead',
+			useDisableSwipeForModalInstead: 'Using `enable-swipe` is deprecated - use `disable-swipe` instead',
+			useNoFocusTrapInstead: 'Using `focus-trap` is deprecated - use `no-focus-trap` instead',
+			useKeepOpenInstead: 'Using `close-on-select` is deprecated - use `keep-open` instead',
+			useNcSelectUsersInstead: 'Using `user-select` is deprecated - use `NcSelectUsers` component instead',
+			removeAriaHidden: 'Using `aria-hidden` is deprecated - remove prop from components, otherwise root element will inherit incorrect attribute.',
 		},
 	},
 
@@ -83,6 +95,99 @@ export default {
 							return fixer.replaceTextRange(node.key.argument.range, 'type')
 						}
 					},
+				})
+			},
+
+			'VElement VAttribute:has(VIdentifier[name="aria-hidden"])': function(node) {
+				if (node.parent.parent.name.startsWith('ncaction')
+					|| node.parent.parent.name === 'ncbutton') {
+					context.report({
+						node,
+						messageId: 'removeAriaHidden',
+					})
+				}
+			},
+
+			'VElement[name="ncappcontent"] VAttribute:has(VIdentifier[name="allow-swipe-navigation"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useDisableSwipeForNavInstead',
+				})
+			},
+
+			'VElement[name="ncavatar"] VAttribute:has(VIdentifier[name="show-user-status"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useHideStatusInstead',
+				})
+			},
+
+			'VElement[name="ncavatar"] VAttribute:has(VIdentifier[name="show-user-status-compact"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useVerboseStatusInstead',
+				})
+			},
+
+			'VElement[name="ncavatar"] VAttribute:has(VIdentifier[name="allow-placeholder"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useNoPlaceholderInstead',
+				})
+			},
+
+			'VElement[name="ncdatetimepicker"] VAttribute:has(VIdentifier[name="formatter"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useFormatInstead',
+				})
+			},
+
+			'VElement[name="ncdatetimepicker"] VAttribute:has(VIdentifier[name="range"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useTypeDateRangeInstead',
+				})
+			},
+
+			'VElement VAttribute:has(VIdentifier[name="can-close"])': function(node) {
+				if (![
+					'ncdialog',
+					'ncmodal',
+				].includes(node.parent.parent.name)) {
+					return
+				}
+				context.report({
+					node,
+					messageId: 'useNoCloseInstead',
+				})
+			},
+
+			'VElement[name="ncmodal"] VAttribute:has(VIdentifier[name="enable-swipe"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useDisableSwipeForModalInstead',
+				})
+			},
+
+			'VElement[name="ncpopover"] VAttribute:has(VIdentifier[name="focus-trap"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useNoFocusTrapInstead',
+				})
+			},
+
+			'VElement[name="ncselect"] VAttribute:has(VIdentifier[name="close-on-select"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useKeepOpenInstead',
+				})
+			},
+
+			'VElement[name="ncselect"] VAttribute:has(VIdentifier[name="user-select"])': function(node) {
+				context.report({
+					node,
+					messageId: 'useNcSelectUsersInstead',
 				})
 			},
 		})


### PR DESCRIPTION
Check more props
Found by looking at `@deprecated` at nextcloud-vue stable branch

Result for spreed repo (I was mostly migrating all props once they've been released)
<img width="703" alt="2025-06-05_14h50_29" src="https://github.com/user-attachments/assets/886386af-93f0-4341-a7da-d2c7c9361e52" />
