### PR TITLE
fix(no-deprecated-props): respect nextcloud/vue library version for the rule

### DIFF
--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
@@ -2,14 +2,12 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 import { RuleTester } from 'eslint'
 import { fs, vol } from 'memfs'
 import { afterAll, beforeAll, describe, test, vi } from 'vitest'
+import vueParser from 'vue-eslint-parser'
 import rule from './no-deprecated-exports.ts'
-
-// ------------------------------------------------------------------------------
-// Tests
-// ------------------------------------------------------------------------------
 
 vi.mock('node:fs', () => fs)
 
@@ -20,7 +18,12 @@ describe('no-deprecated-exports', () => {
 	}))
 	afterAll(() => vol.reset())
 
-	const ruleTester = new RuleTester()
+	const ruleTester = new RuleTester({
+		languageOptions: {
+			parser: vueParser,
+			ecmaVersion: 2015,
+		},
+	})
 
 	test('no-deprecated-exports if library is not in use', () => {
 		vol.fromNestedJSON({
@@ -32,11 +35,17 @@ describe('no-deprecated-exports', () => {
 		ruleTester.run('no-deprecated-exports', rule, {
 			valid: [
 				{
-					code: "import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'",
-					filename: '/a/src/component.js',
+					code: '<script>import anything from \'anywhere\'</script>',
+					filename: '/a/src/component.vue',
 				},
 			],
-			invalid: [],
+			invalid: [
+				{
+					code: '<script>import NcButton from \'@nextcloud/vue/dist/Components/NcButton.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'outdatedVueLibrary' }],
+				},
+			],
 		})
 	})
 
@@ -50,11 +59,17 @@ describe('no-deprecated-exports', () => {
 		ruleTester.run('no-deprecated-exports', rule, {
 			valid: [
 				{
-					code: "import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'",
-					filename: '/a/src/component.js',
+					code: '<script>import anything from \'anywhere\'</script>',
+					filename: '/a/src/component.vue',
 				},
 			],
-			invalid: [],
+			invalid: [
+				{
+					code: '<script>import NcButton from \'@nextcloud/vue/dist/Components/NcButton.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'outdatedVueLibrary' }],
+				},
+			],
 		})
 	})
 
@@ -68,77 +83,47 @@ describe('no-deprecated-exports', () => {
 		ruleTester.run('no-deprecated-exports', rule, {
 			valid: [
 				{
-					code: "import NcButton from '@nextcloud/vue/components/NcButton'",
-					filename: '/a/src/component.js',
+					code: '<script>import NcButton from \'@nextcloud/vue/components/NcButton\'</script>',
+					filename: '/a/src/component.vue',
 				},
 			],
 
 			invalid: [
 				{
-					code: "import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'",
-					filename: '/a/src/component.js',
-					errors: [
-						{
-							message: 'Import from "@nextcloud/vue/dist" is deprecated',
-							type: 'ImportDeclaration',
-						},
-					],
-					output: 'import NcButton from \'@nextcloud/vue/components/NcButton\'',
+					code: '<script>import NcButton from \'@nextcloud/vue/dist/Components/NcButton.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedDist' }],
+					output: '<script>import NcButton from \'@nextcloud/vue/components/NcButton\'</script>',
 				},
 				{
-					code: "import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'",
-					filename: '/a/src/component.js',
-					errors: [
-						{
-							message: 'Import from "@nextcloud/vue/dist" is deprecated',
-							type: 'ImportDeclaration',
-						},
-					],
-					output: 'import Tooltip from \'@nextcloud/vue/directives/Tooltip\'',
+					code: '<script>import Tooltip from \'@nextcloud/vue/dist/Directives/Tooltip.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedDist' }],
+					output: '<script>import Tooltip from \'@nextcloud/vue/directives/Tooltip\'</script>',
 				},
 				{
-					code: "import { emojiSearch } from '@nextcloud/vue/dist/Functions/emoji.js'",
-					filename: '/a/src/component.js',
-					errors: [
-						{
-							message: 'Import from "@nextcloud/vue/dist" is deprecated',
-							type: 'ImportDeclaration',
-						},
-					],
-					output: 'import { emojiSearch } from \'@nextcloud/vue/functions/emoji\'',
+					code: '<script>import { emojiSearch } from \'@nextcloud/vue/dist/Functions/emoji.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedDist' }],
+					output: '<script>import { emojiSearch } from \'@nextcloud/vue/functions/emoji\'</script>',
 				},
 				{
-					code: "import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'",
-					filename: '/a/src/component.js',
-					errors: [
-						{
-							message: 'Import from "@nextcloud/vue/dist" is deprecated',
-							type: 'ImportDeclaration',
-						},
-					],
-					output: 'import { useHotKey } from \'@nextcloud/vue/composables/useHotKey\'',
+					code: '<script>import { useHotKey } from \'@nextcloud/vue/dist/Composables/useHotKey.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedDist' }],
+					output: '<script>import { useHotKey } from \'@nextcloud/vue/composables/useHotKey\'</script>',
 				},
 				{
-					code: "import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey/index.js'",
-					filename: '/a/src/component.js',
-					errors: [
-						{
-							message: 'Import from "@nextcloud/vue/dist" is deprecated',
-							type: 'ImportDeclaration',
-						},
-					],
-					output: 'import { useHotKey } from \'@nextcloud/vue/composables/useHotKey\'',
+					code: '<script>import { useHotKey } from \'@nextcloud/vue/dist/Composables/useHotKey/index.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedDist' }],
+					output: '<script>import { useHotKey } from \'@nextcloud/vue/composables/useHotKey\'</script>',
 				},
 				{
-					code: "import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'",
-					filename: '/a/src/component.js',
-					errors: [
-						{
-							message: 'Import from "@nextcloud/vue/dist" is deprecated',
-							type: 'ImportDeclaration',
-						},
-					],
-					output: 'import isMobile from \'@nextcloud/vue/mixins/isMobile\'',
+					code: '<script>import isMobile from \'@nextcloud/vue/dist/Mixins/isMobile.js\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedDist' }],
+					output: '<script>import isMobile from \'@nextcloud/vue/mixins/isMobile\'</script>',
 				},
 			],
 		})

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
@@ -22,7 +22,10 @@ const rule: Rule.RuleModule = {
 			recommended: true,
 		},
 		fixable: 'code',
-		schema: [],
+		messages: {
+			outdatedVueLibrary: 'Installed @nextcloud/vue library is outdated and does not support all reported errors. Install latest compatible version',
+			deprecatedDist: 'Import from "@nextcloud/vue/dist" is deprecated',
+		},
 	},
 
 	create(context) {
@@ -33,19 +36,19 @@ const rule: Rule.RuleModule = {
 
 		return {
 			ImportDeclaration: function(node) {
-				if (!isVersionValid) {
-					// Can't fix, ignore the rule
-					return
-				}
-
 				const importPath = node.source.value as string
 				const match = importPath.match(new RegExp(oldPattern))
 
 				if (match) {
+					if (!isVersionValid) {
+						context.report({ node, messageId: 'outdatedVueLibrary' })
+						return
+					}
+
 					const newImportPath = `'@nextcloud/vue/${match[1].toLowerCase()}/${match[2]}'`
 					context.report({
 						node,
-						message: 'Import from "@nextcloud/vue/dist" is deprecated',
+						messageId: 'deprecatedDist',
 						fix(fixer) {
 							return fixer.replaceText(node.source, newImportPath)
 						},

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
@@ -4,202 +4,272 @@
  */
 
 import { RuleTester } from 'eslint'
-import { describe, test } from 'vitest'
+import { fs, vol } from 'memfs'
+import { afterAll, beforeAll, describe, test, vi } from 'vitest'
 import vueParser from 'vue-eslint-parser'
 import rule from './no-deprecated-props.ts'
 
-RuleTester.describe = describe
-RuleTester.it = test
+vi.mock('node:fs', () => fs)
 
-const ruleTester = new RuleTester({
-	languageOptions: {
-		parser: vueParser,
-		ecmaVersion: 2015,
-	},
-})
+describe('no-deprecated-props', () => {
+	beforeAll(() => vol.fromNestedJSON({
+		[__dirname]: {},
+		[__filename]: '...',
+	}))
+	afterAll(() => vol.reset())
 
-ruleTester.run('no-deprecated-props', rule, {
-	valid: [
-		{
-			code: '<template><NcButton variant="primary">Hello</NcButton></template>',
-			filename: 'test.vue',
+	const ruleTester = new RuleTester({
+		languageOptions: {
+			parser: vueParser,
+			ecmaVersion: 2015,
 		},
-		{
-			code: '<template><NcButton type="submit">Hello</NcButton></template>',
-			filename: 'test.vue',
-		},
-		{
-			code: '<template><NcButton variant="tertiary-no-background" type="reset">Hello</NcButton></template>',
-			filename: 'test.vue',
-		},
-		{
-			code: '<template><NcButton :type="isReset ? \'reset\' : \'submit\'">Hello</NcButton></template>',
-			filename: 'test.vue',
-		},
-		{
-			code: '<template><NcButton :variant="isPrimary ? \'primary\' : \'tertiary\'">Hello</NcButton></template>',
-			filename: 'test.vue',
-		},
-	],
-	invalid: [
-		{
-			code: '<template><NcButton type="primary">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcButton variant="primary">Hello</NcButton></template>',
-		},
-		{
-			code: '<template><NcActions type="primary">Hello</NcActions></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcActions variant="primary">Hello</NcActions></template>',
-		},
-		{
-			code: '<template><NcAppNavigationNew type="primary" text="Hello" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcAppNavigationNew variant="primary" text="Hello" /></template>',
-		},
-		{
-			code: '<template><NcChip type="primary" text="Hello" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcChip variant="primary" text="Hello" /></template>',
-		},
-		{
-			code: '<template><NcDialogButton type="primary">Hello</NcDialogButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcDialogButton variant="primary">Hello</NcDialogButton></template>',
-		},
-		{
-			code: '<template><NcButton type="tertiary">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcButton variant="tertiary">Hello</NcButton></template>',
-		},
-		{
-			code: '<template><NcButton type="error">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcButton variant="error">Hello</NcButton></template>',
-		},
-		{
-			code: '<template><NcButton native-type="button">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useTypeInstead' }],
-			output: '<template><NcButton type="button">Hello</NcButton></template>',
-		},
-		{
-			code: '<template><NcDialogButton native-type="button">Hello</NcDialogButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useTypeInstead' }],
-			output: '<template><NcDialogButton type="button">Hello</NcDialogButton></template>',
-		},
-		{
-			code: '<template><NcButton type="primary" native-type="button">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }, { messageId: 'useTypeInstead' }],
-			output: '<template><NcButton variant="primary" type="button">Hello</NcButton></template>',
-		},
-		{
-			code: '<template><NcButton :type="isPrimary ? \'primary\' : \'secondary\'">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcButton :variant="isPrimary ? \'primary\' : \'secondary\'">Hello</NcButton></template>',
-		},
-		{
-			code: '<template><NcButton :type="buttonType" :native-type="nativeType">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }, { messageId: 'useTypeInstead' }],
-			output: '<template><NcButton :variant="buttonType" :type="nativeType">Hello</NcButton></template>',
-		},
-		// from Talk app
-		{
-			code: '<template><NcButton v-show="!loading" type="tertiary" @click="handle"><template #icon><IconDelete /></template></NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVariantInstead' }],
-			output: '<template><NcButton v-show="!loading" variant="tertiary" @click="handle"><template #icon><IconDelete /></template></NcButton></template>',
-		},
-		{
-			code: '<template><NcActionButton aria-hidden @click="handle">Hello</NcActionButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'removeAriaHidden' }],
-		},
-		{
-			code: '<template><NcButton aria-hidden @click="handle">Hello</NcButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'removeAriaHidden' }],
-		},
-		{
-			code: '<template><NcActionButton :aria-hidden="true" @click="handle">Hello</NcActionButton></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'removeAriaHidden' }],
-		},
-		{
-			code: '<template><NcAppContent allow-swipe-navigation @click="handle">Hello</NcAppContent></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
-		},
-		{
-			code: '<template><NcAppContent :allow-swipe-navigation="false" @click="handle">Hello</NcAppContent></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
-		},
-		{
-			code: '<template><NcAvatar :show-user-status="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useHideStatusInstead' }],
-		},
-		{
-			code: '<template><NcAvatar :show-user-status-compact="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useVerboseStatusInstead' }],
-		},
-		{
-			code: '<template><NcAvatar :allow-placeholder="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useNoPlaceholderInstead' }],
-		},
-		{
-			code: '<template><NcDateTimePicker :formatter="customFormatter" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useFormatInstead' }],
-		},
-		{
-			code: '<template><NcDateTimePicker range /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useTypeDateRangeInstead' }],
-		},
-		{
-			code: '<template><NcDialog :can-close="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useNoCloseInstead' }],
-		},
-		{
-			code: '<template><NcModal :can-close="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useNoCloseInstead' }],
-		},
-		{
-			code: '<template><NcModal :enable-swipe="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useDisableSwipeForModalInstead' }],
-		},
-		{
-			code: '<template><NcPopover :focus-trap="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useNoFocusTrapInstead' }],
-		},
-		{
-			code: '<template><NcSelect :close-on-select="false" /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useKeepOpenInstead' }],
-		},
-		{
-			code: '<template><NcSelect user-select /></template>',
-			filename: 'test.vue',
-			errors: [{ messageId: 'useNcSelectUsersInstead' }],
-		},
-	],
+	})
+
+	test('no-deprecated-props if library is not in use', () => {
+		console.log('only ttests')
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0"}',
+				src: { },
+			},
+		}, '/a/src')
+		ruleTester.run('no-deprecated-props', rule, {
+			valid: [
+				{
+					code: '<template><NcButton>Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+			],
+			invalid: [
+				{
+					code: '<template><NcButton type="primary">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'outdatedVueLibrary' }],
+				},
+			],
+		})
+	})
+
+	test('no-deprecated-props if library has outdated version', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
+				src: { },
+			},
+		})
+		ruleTester.run('no-deprecated-props', rule, {
+			valid: [
+				{
+					code: '<template><NcButton>Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+			],
+			invalid: [
+				{
+					code: '<template><NcButton type="primary">Hello</NcButton></template>', // Since 8.24.0
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'outdatedVueLibrary' }],
+				},
+				{
+					code: '<template><NcAppContent allow-swipe-navigation @click="handle">Hello</NcAppContent></template>', // Since 8.23.0
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
+				},
+			],
+		})
+	})
+
+	test('no-deprecated-props', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.27.1"}}',
+				src: { },
+			},
+		})
+		ruleTester.run('no-deprecated-props', rule, {
+			valid: [
+				{
+					code: '<template><NcButton variant="primary">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+				{
+					code: '<template><NcButton type="submit">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+				{
+					code: '<template><NcButton variant="tertiary-no-background" type="reset">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+				{
+					code: '<template><NcButton :type="isReset ? \'reset\' : \'submit\'">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+				{
+					code: '<template><NcButton :variant="isPrimary ? \'primary\' : \'tertiary\'">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+				},
+			],
+			invalid: [
+				{
+					code: '<template><NcButton type="primary">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcButton variant="primary">Hello</NcButton></template>',
+				},
+				{
+					code: '<template><NcActions type="primary">Hello</NcActions></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcActions variant="primary">Hello</NcActions></template>',
+				},
+				{
+					code: '<template><NcAppNavigationNew type="primary" text="Hello" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcAppNavigationNew variant="primary" text="Hello" /></template>',
+				},
+				{
+					code: '<template><NcChip type="primary" text="Hello" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcChip variant="primary" text="Hello" /></template>',
+				},
+				{
+					code: '<template><NcDialogButton type="primary">Hello</NcDialogButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcDialogButton variant="primary">Hello</NcDialogButton></template>',
+				},
+				{
+					code: '<template><NcButton type="tertiary">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcButton variant="tertiary">Hello</NcButton></template>',
+				},
+				{
+					code: '<template><NcButton type="error">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcButton variant="error">Hello</NcButton></template>',
+				},
+				{
+					code: '<template><NcButton native-type="button">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useTypeInstead' }],
+					output: '<template><NcButton type="button">Hello</NcButton></template>',
+				},
+				{
+					code: '<template><NcDialogButton native-type="button">Hello</NcDialogButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useTypeInstead' }],
+					output: '<template><NcDialogButton type="button">Hello</NcDialogButton></template>',
+				},
+				{
+					code: '<template><NcButton type="primary" native-type="button">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }, { messageId: 'useTypeInstead' }],
+					output: '<template><NcButton variant="primary" type="button">Hello</NcButton></template>',
+				},
+				{
+					code: '<template><NcButton :type="isPrimary ? \'primary\' : \'secondary\'">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcButton :variant="isPrimary ? \'primary\' : \'secondary\'">Hello</NcButton></template>',
+				},
+				{
+					code: '<template><NcButton :type="buttonType" :native-type="nativeType">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }, { messageId: 'useTypeInstead' }],
+					output: '<template><NcButton :variant="buttonType" :type="nativeType">Hello</NcButton></template>',
+				},
+				// from Talk app
+				{
+					code: '<template><NcButton v-show="!loading" type="tertiary" @click="handle"><template #icon><IconDelete /></template></NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVariantInstead' }],
+					output: '<template><NcButton v-show="!loading" variant="tertiary" @click="handle"><template #icon><IconDelete /></template></NcButton></template>',
+				},
+				{
+					code: '<template><NcActionButton aria-hidden @click="handle">Hello</NcActionButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'removeAriaHidden' }],
+				},
+				{
+					code: '<template><NcButton aria-hidden @click="handle">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'removeAriaHidden' }],
+				},
+				{
+					code: '<template><NcActionButton :aria-hidden="true" @click="handle">Hello</NcActionButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'removeAriaHidden' }],
+				},
+				{
+					code: '<template><NcAppContent allow-swipe-navigation @click="handle">Hello</NcAppContent></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
+				},
+				{
+					code: '<template><NcAppContent :allow-swipe-navigation="false" @click="handle">Hello</NcAppContent></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useDisableSwipeForNavInstead' }],
+				},
+				{
+					code: '<template><NcAvatar :show-user-status="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useHideStatusInstead' }],
+				},
+				{
+					code: '<template><NcAvatar :show-user-status-compact="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useVerboseStatusInstead' }],
+				},
+				{
+					code: '<template><NcAvatar :allow-placeholder="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNoPlaceholderInstead' }],
+				},
+				{
+					code: '<template><NcDateTimePicker :formatter="customFormatter" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useFormatInstead' }],
+				},
+				{
+					code: '<template><NcDateTimePicker range /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useTypeDateRangeInstead' }],
+				},
+				{
+					code: '<template><NcDialog :can-close="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNoCloseInstead' }],
+				},
+				{
+					code: '<template><NcModal :can-close="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNoCloseInstead' }],
+				},
+				{
+					code: '<template><NcModal :enable-swipe="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useDisableSwipeForModalInstead' }],
+				},
+				{
+					code: '<template><NcPopover :focus-trap="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNoFocusTrapInstead' }],
+				},
+				{
+					code: '<template><NcSelect :close-on-select="false" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useKeepOpenInstead' }],
+				},
+				{
+					code: '<template><NcSelect user-select /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNcSelectUsersInstead' }],
+				},
+			],
+		})
+	})
 })

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
@@ -5,6 +5,7 @@
 import type { Rule } from 'eslint'
 
 import * as vueUtils from 'eslint-plugin-vue/lib/utils/index.js'
+import { createLibVersionValidator } from '../utils/lib-version-parser.ts'
 
 export default {
 	meta: {
@@ -14,6 +15,7 @@ export default {
 		type: 'problem',
 		fixable: 'code',
 		messages: {
+			outdatedVueLibrary: 'Installed @nextcloud/vue library is outdated and does not support all reported errors. Install latest compatible version',
 			useTypeInstead: 'Using `native-type` for button variant is deprecated - use `type` instead.',
 			useVariantInstead: 'Using `type` for button variant is deprecated - use `variant` instead.',
 			useDisableSwipeForNavInstead: 'Using `allow-swipe-navigation` is deprecated - use `disable-swipe` instead',
@@ -32,6 +34,16 @@ export default {
 	},
 
 	create(context) {
+		const versionSatisfies = createLibVersionValidator(context)
+		const isAriaHiddenValid = versionSatisfies('8.2.0') // #4835
+		const isDisableSwipeValid = versionSatisfies('8.23.0') // #6452
+		const isVariantTypeValid = versionSatisfies('8.24.0') // #6472
+		const isDefaultBooleanFalseValid = versionSatisfies('8.24.0') // #6656
+		const isDateTimePickerFormatValid = versionSatisfies('8.25.0') // #6738
+		const isNcSelectKeepOpenValid = versionSatisfies('8.25.0') // #6791
+		const isNcPopoverNoFocusTrapValid = versionSatisfies('8.26.0') // #6808
+		const isNcSelectUsersValid = versionSatisfies('8.27.1') // #7032
+
 		const legacyTypes = ['primary', 'error', 'warning', 'success', 'secondary', 'tertiary', 'tertiary-no-background']
 
 		return vueUtils.defineTemplateBodyVisitor(context, {
@@ -43,6 +55,11 @@ export default {
 					'ncchip',
 					'ncdialogbutton',
 				].includes(node.parent.parent.name)) {
+					return
+				}
+
+				if (!isVariantTypeValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
 					return
 				}
 
@@ -85,6 +102,11 @@ export default {
 					return
 				}
 
+				if (!isVariantTypeValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useTypeInstead',
@@ -101,6 +123,11 @@ export default {
 			'VElement VAttribute:has(VIdentifier[name="aria-hidden"])': function(node) {
 				if (node.parent.parent.name.startsWith('ncaction')
 					|| node.parent.parent.name === 'ncbutton') {
+					if (!isAriaHiddenValid) {
+						context.report({ node, messageId: 'outdatedVueLibrary' })
+						return
+					}
+
 					context.report({
 						node,
 						messageId: 'removeAriaHidden',
@@ -109,6 +136,11 @@ export default {
 			},
 
 			'VElement[name="ncappcontent"] VAttribute:has(VIdentifier[name="allow-swipe-navigation"])': function(node) {
+				if (!isDisableSwipeValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useDisableSwipeForNavInstead',
@@ -116,6 +148,11 @@ export default {
 			},
 
 			'VElement[name="ncavatar"] VAttribute:has(VIdentifier[name="show-user-status"])': function(node) {
+				if (!isDefaultBooleanFalseValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useHideStatusInstead',
@@ -123,6 +160,11 @@ export default {
 			},
 
 			'VElement[name="ncavatar"] VAttribute:has(VIdentifier[name="show-user-status-compact"])': function(node) {
+				if (!isDefaultBooleanFalseValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useVerboseStatusInstead',
@@ -130,6 +172,11 @@ export default {
 			},
 
 			'VElement[name="ncavatar"] VAttribute:has(VIdentifier[name="allow-placeholder"])': function(node) {
+				if (!isDefaultBooleanFalseValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useNoPlaceholderInstead',
@@ -137,6 +184,11 @@ export default {
 			},
 
 			'VElement[name="ncdatetimepicker"] VAttribute:has(VIdentifier[name="formatter"])': function(node) {
+				if (!isDateTimePickerFormatValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useFormatInstead',
@@ -144,6 +196,11 @@ export default {
 			},
 
 			'VElement[name="ncdatetimepicker"] VAttribute:has(VIdentifier[name="range"])': function(node) {
+				if (!isDateTimePickerFormatValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useTypeDateRangeInstead',
@@ -157,6 +214,12 @@ export default {
 				].includes(node.parent.parent.name)) {
 					return
 				}
+
+				if (!isDefaultBooleanFalseValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useNoCloseInstead',
@@ -164,6 +227,11 @@ export default {
 			},
 
 			'VElement[name="ncmodal"] VAttribute:has(VIdentifier[name="enable-swipe"])': function(node) {
+				if (!isDisableSwipeValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useDisableSwipeForModalInstead',
@@ -171,6 +239,11 @@ export default {
 			},
 
 			'VElement[name="ncpopover"] VAttribute:has(VIdentifier[name="focus-trap"])': function(node) {
+				if (!isNcPopoverNoFocusTrapValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useNoFocusTrapInstead',
@@ -178,6 +251,11 @@ export default {
 			},
 
 			'VElement[name="ncselect"] VAttribute:has(VIdentifier[name="close-on-select"])': function(node) {
+				if (!isNcSelectKeepOpenValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useKeepOpenInstead',
@@ -185,6 +263,11 @@ export default {
 			},
 
 			'VElement[name="ncselect"] VAttribute:has(VIdentifier[name="user-select"])': function(node) {
+				if (!isNcSelectUsersValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
 				context.report({
 					node,
 					messageId: 'useNcSelectUsersInstead',


### PR DESCRIPTION
Require installed library version check before linting the file

Inspired by https://github.com/nextcloud-libraries/nextcloud-vue/pull/7032 - we should not force the rule or highlight the error, if component is not working correctly in this lib version

Other examples:
```js
const isAriaHiddenValid = versionSatisfies('8.2.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/4835
const isDisableSwipeValid = versionSatisfies('8.23.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/6452
const isVariantTypeValid = versionSatisfies('8.24.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/6472
const isDefaultBooleanFalseValid = versionSatisfies('8.24.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/6656
const isDateTimePickerFormatValid = versionSatisfies('8.25.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/6738
const isNcSelectKeepOpenValid = versionSatisfies('8.25.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/6791
const isNcPopoverNoFocusTrapValid = versionSatisfies('8.26.0') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/6808
const isNcSelectUsersValid = versionSatisfies('8.27.1') // https://github.com/nextcloud-libraries/nextcloud-vue/pull/7032
```