### PR TITLE
fix: ignore test report directories from linting

### DIFF
--- a/lib/configs/filesystem.ts
+++ b/lib/configs/filesystem.ts
@@ -12,9 +12,11 @@ export const filesystem: Linter.Config[] = [
 	{
 		name: 'nextcloud/filesystem/ignores',
 		ignores: [
+			'**/coverage',
 			'**/dist',
 			'**/js',
 			'**/l10n',
+			'**/playwright-report',
 			'**/vendor',
 			'**/vendor-bin',
 			'**/package-lock.json',


### PR DESCRIPTION
Noticed while linting.
If there's more known libraries to add (from what we're using), let me know