### PR TITLE
feat(imports): add custom plugin to suggest file extensions

### DIFF
--- a/lib/configs/imports.ts
+++ b/lib/configs/imports.ts
@@ -11,6 +11,7 @@ import {
 	GLOB_FILES_TYPESCRIPT,
 	GLOB_FILES_VUE,
 } from '../globs.ts'
+import importExtensions from '../plugins/import-extensions/index.ts'
 
 /**
  * Generate imports and exports related ESLint rules.
@@ -24,6 +25,7 @@ export function imports(options: ConfigOptions): Linter.Config[] {
 			name: 'nextcloud/imports/setup',
 			plugins: {
 				perfectionist,
+				'import-extensions': importExtensions,
 			},
 		},
 		{
@@ -35,17 +37,7 @@ export function imports(options: ConfigOptions): Linter.Config[] {
 			],
 			rules: {
 				// Require file extensions
-				'no-restricted-imports': [
-					'error',
-					{
-						patterns: [
-							{
-								regex: '^(\\.*)/(.+/)*[^/.]+$',
-								message: 'Import is missing the file extension.',
-							},
-						],
-					},
-				],
+				'import-extensions/extensions': 'error',
 				// Sorting of imports
 				'sort-imports': 'off',
 				'perfectionist/sort-imports': [

--- a/lib/plugins/import-extensions/index.ts
+++ b/lib/plugins/import-extensions/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ESLint } from 'eslint'
+
+import { packageVersion } from '../../version.ts'
+import { rules } from './rules/index.ts'
+
+export default {
+	rules,
+	meta: {
+		name: '@nextcloud/eslint-plugin',
+		version: packageVersion,
+	},
+} satisfies ESLint.Plugin

--- a/lib/plugins/import-extensions/rules/extensions.test.ts
+++ b/lib/plugins/import-extensions/rules/extensions.test.ts
@@ -1,0 +1,316 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { RuleTester } from 'eslint'
+import { fs, vol } from 'memfs'
+import { beforeEach, test, vi } from 'vitest'
+import rule, { clearCache } from './extensions.ts'
+
+vi.mock('fs', () => fs)
+vi.mock('node:fs', () => fs)
+
+const ruleTester = new RuleTester()
+
+beforeEach(() => {
+	vol.reset()
+	clearCache()
+})
+
+test('import-extensions: relative files', () => {
+	vol.fromNestedJSON({
+		'/a': {
+			css: {
+				'some.css': '/* ... */',
+			},
+			img: {
+				'icon.svg': '<svg />',
+			},
+			src: {
+				'main.js': 'import { join } from "node:path"',
+				'view.vue': '<template><div>hello</div></template>',
+				'component.vue': '<template><div>hello</div></template>',
+				'component.css': '/* ... */',
+
+				nested: {
+					'child.ts': '/* ... */',
+				},
+			},
+		},
+	}, '/a')
+
+	ruleTester.run('imports', rule, {
+		valid: [
+			{
+				code: 'import { join } from "node:path"',
+				filename: '/a/src/test1.js',
+			},
+			{
+				code: 'import * as main from "./main.js"',
+				filename: '/a/src/test2.js',
+			},
+			{
+				code: 'import View from "./view.vue"',
+				filename: '/a/src/test3.js',
+			},
+			{
+				code: 'import * as child from "./nested/child.ts"',
+				filename: '/a/src/test4.js',
+			},
+			{
+				code: 'import * as main from "../main.js"',
+				filename: '/a/src/nested/test.js',
+			},
+			{
+				code: 'import svg from "../img/icon.svg?raw"',
+				filename: '/a/src/test.js',
+			},
+		],
+		invalid: [
+			// missing extension in same folder
+			{
+				code: 'import "./main"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.js', type: 'import' },
+						output: 'import "./main.js"',
+					}],
+				}],
+			},
+			// missing extension in same folder - non node resolveable
+			{
+				code: 'import View from "./view"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.vue', type: 'import' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.vue', type: 'import' },
+						output: 'import View from "./view.vue"',
+					}],
+				}],
+			},
+			// missing extension in nested folder
+			{
+				code: 'import * as child from "./nested/child"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.ts', type: 'import' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.ts', type: 'import' },
+						output: 'import * as child from "./nested/child.ts"',
+					}],
+				}],
+			},
+			// missing extension in parent folder
+			{
+				code: 'import * as main from "../main"',
+				filename: '/a/src/nested/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.js', type: 'import' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.js', type: 'import' },
+						output: 'import * as main from "../main.js"',
+					}],
+				}],
+			},
+			// missing extension of non node resolvable file
+			{
+				code: 'import "../css/some"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.css', type: 'import' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.css', type: 'import' },
+						output: 'import "../css/some.css"',
+					}],
+				}],
+			},
+			// with import query
+			{
+				code: 'import svg from "../img/icon?raw"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.svg', type: 'import' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.svg', type: 'import' },
+						output: 'import svg from "../img/icon.svg?raw"',
+					}],
+				}],
+			},
+			// missing extension non unique name
+			{
+				code: 'import "./component"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'missingExtension',
+					data: { type: 'import' },
+					suggestions: [
+						{
+							messageId: 'applySuggestedExtension',
+							data: { extension: '.vue', type: 'import' },
+							output: 'import "./component.vue"',
+						},
+						{
+							messageId: 'applySuggestedExtension',
+							data: { extension: '.css', type: 'import' },
+							output: 'import "./component.css"',
+						},
+					],
+				}],
+			},
+			// non existing file
+			{
+				code: 'import "./nop/foo"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'missingExtension',
+					data: { type: 'import' },
+				}],
+			},
+		],
+	})
+})
+
+test('import-extensions: exports', () => {
+	vol.fromNestedJSON({
+		'/a': {
+			src: {
+				'main.js': 'import { join } from "node:path"',
+				'view.vue': '<template><div>hello</div></template>',
+				'component.vue': '<template><div>hello</div></template>',
+				'component.jsx': '/* ... */',
+
+				nested: {
+					'child.ts': '/* ... */',
+				},
+			},
+		},
+	}, '/a')
+
+	ruleTester.run('exports', rule, {
+		valid: [
+			{
+				code: 'export { join } from "node:path"',
+				filename: '/a/src/test1.js',
+			},
+			{
+				code: 'export * as main from "./main.js"',
+				filename: '/a/src/test2.js',
+			},
+			{
+				code: 'export { default as View } from "./view.vue"',
+				filename: '/a/src/test3.js',
+			},
+			{
+				code: 'export * from "./nested/child.ts"',
+				filename: '/a/src/test4.js',
+			},
+			{
+				code: 'export * from "../main.js"',
+				filename: '/a/src/nested/test.js',
+			},
+		],
+		invalid: [
+			// missing extension in same folder
+			{
+				code: 'export * from "./main"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.js', type: 'export' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.js', type: 'export' },
+						output: 'export * from "./main.js"',
+					}],
+				}],
+			},
+			// missing extension in same folder - non node resolveable
+			{
+				code: 'export { default as View } from "./view"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.vue', type: 'export' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.vue', type: 'export' },
+						output: 'export { default as View } from "./view.vue"',
+					}],
+				}],
+			},
+			// missing extension in nested folder
+			{
+				code: 'export * from "./nested/child"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.ts', type: 'export' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.ts', type: 'export' },
+						output: 'export * from "./nested/child.ts"',
+					}],
+				}],
+			},
+			// missing extension in parent folder
+			{
+				code: 'export * from "../main"',
+				filename: '/a/src/nested/test.js',
+				errors: [{
+					messageId: 'recommendedMissingExtension',
+					data: { extension: '.js', type: 'export' },
+					suggestions: [{
+						messageId: 'applySuggestedExtension',
+						data: { extension: '.js', type: 'export' },
+						output: 'export * from "../main.js"',
+					}],
+				}],
+			},
+			// missing extension non unique name
+			{
+				code: 'export { default as MyComponent } from "./component"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'missingExtension',
+					data: { type: 'export' },
+					suggestions: [
+						{
+							messageId: 'applySuggestedExtension',
+							data: { extension: '.vue', type: 'export' },
+							output: 'export { default as MyComponent } from "./component.vue"',
+						},
+						{
+							messageId: 'applySuggestedExtension',
+							data: { extension: '.jsx', type: 'export' },
+							output: 'export { default as MyComponent } from "./component.jsx"',
+						},
+					],
+				}],
+			},
+			// non existing file
+			{
+				code: 'export * from "./nop/foo"',
+				filename: '/a/src/test.js',
+				errors: [{
+					messageId: 'missingExtension',
+					data: { type: 'export' },
+				}],
+			},
+		],
+	})
+})

--- a/lib/plugins/import-extensions/rules/extensions.ts
+++ b/lib/plugins/import-extensions/rules/extensions.ts
@@ -1,0 +1,160 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Rule } from 'eslint'
+import type { Literal } from 'estree'
+import type { Dirent } from 'fs'
+
+import { existsSync, opendirSync, statSync } from 'fs'
+import { basename, dirname, extname, join, resolve } from 'path'
+
+// we use this module scope map to cache results for resolving the file extensions
+// in larger projects its likely the same files are imported so we cache "absolute resolved import without extension" -> array of possible extensions
+const fsCache = new Map<string, string[]>()
+
+/**
+ * helper for unit tests
+ */
+export function clearCache() {
+	fsCache.clear()
+}
+
+export const rule: Rule.RuleModule = {
+	meta: {
+		type: 'suggestion',
+		hasSuggestions: true,
+		docs: {
+			description: 'Ensure all relative imports and exports have a file extension',
+		},
+		messages: {
+			missingExtension: 'This relative {{ type }} should have a file extension.',
+			recommendedMissingExtension: 'The relative {{ type }} should probably have the file extension "{{ extension }}".',
+			applySuggestedExtension: 'Add the "{{ extension }}" to the {{ type }}.',
+		},
+	},
+
+	create(context) {
+		/**
+		 * @param node - The ESTree node representing the source
+		 * @param isImport - is this an import or export
+		 */
+		function handleImportExport(node: Literal, isImport = true) {
+			const value = String(node.value)
+			if (!value.includes('/')) {
+				return
+			}
+
+			// get rid of query like ?raw
+			const [text] = value.split('?', 2)
+			if (text.match(/\.[a-z0-9]+$/i)) {
+				return
+			}
+
+			const type = isImport ? 'import' : 'export'
+			// check custom paths - we cannot fix though
+			if (text.startsWith('~/')) {
+				context.report({
+					node,
+					messageId: 'missingExtension',
+					data: { type },
+				})
+			}
+
+			if (!text.match(/^\.\.?\//)) {
+				return
+			}
+
+			const contextPath = dirname(context.physicalFilename)
+			const relativePath = resolve(contextPath, text)
+			const absolutePath = resolve(context.cwd, relativePath)
+			if (!fsCache.has(absolutePath)) {
+				let resolvedPath = relativePath
+				if (existsSync(resolvedPath)) {
+					if (statSync(resolvedPath).isDirectory) {
+						resolvedPath = join(resolvedPath, 'index')
+					} else {
+						// weird extensionless file
+						return
+					}
+				}
+
+				const resolvedDirectoryPath = dirname(resolvedPath)
+				if (existsSync(resolvedDirectoryPath)) {
+					const filename = basename(resolvedPath)
+					const resolvedDir = opendirSync(resolvedDirectoryPath)
+
+					const extensions = []
+					try {
+						let entry: Dirent
+						while ((entry = resolvedDir.readSync()) !== null) {
+							const extension = extname(entry.name)
+							if (extension && `${filename}${extension}` === entry.name) {
+								extensions.push(extension)
+							}
+						}
+					} finally {
+						resolvedDir.close()
+					}
+					fsCache.set(absolutePath, extensions)
+				}
+			}
+
+			if (fsCache.get(absolutePath)?.length) {
+				return context.report({
+					node,
+					messageId: fsCache.get(absolutePath).length === 1
+						? 'recommendedMissingExtension'
+						: 'missingExtension',
+					data: {
+						extension: fsCache.get(absolutePath)[0],
+						type,
+					},
+					suggest: fsCache.get(absolutePath).map((extension) => ({
+						messageId: 'applySuggestedExtension',
+						data: {
+							extension,
+							type,
+						},
+						fix(fixer) {
+							const range: [number, number] = [node.range![0], node.range![0] + 1 + text.length]
+							return fixer.insertTextAfterRange(range, extension)
+						},
+					})),
+				})
+			}
+
+			// no way to fix it
+			context.report({
+				node,
+				messageId: 'missingExtension',
+				data: {
+					type,
+				},
+			})
+		}
+
+		return {
+			ExportAllDeclaration(node) {
+				handleImportExport(node.source, false)
+			},
+			ExportNamedDeclaration(node) {
+				if (node.source) {
+					handleImportExport(node.source, false)
+				}
+			},
+			ImportDeclaration(node) {
+				handleImportExport(node.source)
+			},
+			ImportExpression(node) {
+				if (node.source.type === 'Literal') {
+					handleImportExport(node.source)
+				}
+				// we cannot handle dynamic imports here
+			},
+		}
+	},
+}
+
+export default rule

--- a/lib/plugins/import-extensions/rules/index.ts
+++ b/lib/plugins/import-extensions/rules/index.ts
@@ -1,0 +1,10 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { rule as extensions } from './extensions.ts'
+
+export const rules = {
+	extensions,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/node": "^24.1.0",
         "@types/semver": "^7.7.0",
         "eslint": "^9.32.0",
-        "memfs": "^4.17.2",
+        "memfs": "^4.24.0",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -2562,9 +2562,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.2.tgz",
-      "integrity": "sha512-NgYhCOWgovOXSzvYgUW0LQ7Qy72rWQMGGFJDoWg4G30RHd3z77VbYdtJ4fembJXBy8pMIUA31XNAupobOQlwdg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.24.0.tgz",
+      "integrity": "sha512-PiyWpigBOgdsdvnn4U3PlQytj46ZEw/dMVmcqXuX1KUHoYzaGTL25E9rfK+c26mPAh9RmBdXldoxbQkYbH20Uw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^24.1.0",
     "@types/semver": "^7.7.0",
     "eslint": "^9.32.0",
-    "memfs": "^4.17.2",
+    "memfs": "^4.24.0",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Currently we only forbid file extension less imports / exports. But when migrating large projects this is cumbersome, so instead this is a rather small plugin that just checks if relative imports or exports have file extensions.
If possible it will lookup the file extension from the file system, so no magic resolver is needed.