### PR TITLE
fix(l10n-plugin): also check translation strings in `n` method

### DIFF
--- a/lib/plugins/l10n/rules/enforce-ellipsis.test.ts
+++ b/lib/plugins/l10n/rules/enforce-ellipsis.test.ts
@@ -13,6 +13,15 @@ test('rule: enforce-ellipsis', () => {
 		/* eslint-disable @nextcloud-l10n/non-breaking-space */
 		valid: [
 			{
+				code: 'const foo = t("Loading…")',
+			},
+			{
+				code: 'const foo = n("Loading…", "Loading…", num)',
+			},
+			{
+				code: 'const foo = n("files", "Loading…", "Loading…", num)',
+			},
+			{
 				code: "const foo = '..... done'",
 			},
 			{
@@ -30,32 +39,39 @@ test('rule: enforce-ellipsis', () => {
 			{
 				code: 't("Loading...")',
 				output: 't("Loading…")',
-				errors: [
-					{
-						type: 'Literal',
-						message: 'Strings should ellipsis instead of triple dots',
-					},
-				],
+				errors: [{
+					messageId: 'shoudUseEllipsis',
+				}],
 			},
 			{
 				code: 't("files", "Loading...")',
 				output: 't("files", "Loading…")',
-				errors: [
-					{
-						type: 'Literal',
-						message: 'Strings should ellipsis instead of triple dots',
-					},
-				],
+				errors: [{
+					messageId: 'shoudUseEllipsis',
+				}],
 			},
 			{
 				code: "t('Loading ...')",
 				output: "t('Loading …')",
-				errors: [
-					{
-						type: 'Literal',
-						message: 'Strings should ellipsis instead of triple dots',
-					},
-				],
+				errors: [{
+					messageId: 'shoudUseEllipsis',
+				}],
+			},
+			{
+				code: "const foo = n('Loading %n …', 'Loading %n ...', num)",
+				output: "const foo = n('Loading %n …', 'Loading %n …', num)",
+				errors: [{
+					messageId: 'shoudUseEllipsis',
+				}],
+			},
+			{
+				code: "const foo = n('files', 'Loading %n ...', 'Loading %n ...', num)",
+				output: "const foo = n('files', 'Loading %n …', 'Loading %n …', num)",
+				errors: [{
+					messageId: 'shoudUseEllipsis',
+				}, {
+					messageId: 'shoudUseEllipsis',
+				}],
 			},
 		],
 	})

--- a/lib/plugins/l10n/rules/enforce-ellipsis.ts
+++ b/lib/plugins/l10n/rules/enforce-ellipsis.ts
@@ -14,27 +14,34 @@ export default defineRule({
 		docs: {
 			description: 'Enforce consistent usageof ellipsis instead of tripple dots',
 		},
+		messages: {
+			shoudUseEllipsis: 'Translated strings should use ellipsis character instead of triple dots',
+		}
 	},
 
 	create(context) {
 		return {
-			Literal(node) {
-				if (typeof node.value !== 'string'
-					|| node.parent.type !== 'CallExpression'
-					|| node.parent.callee.type !== 'Identifier'
-					|| node.parent.callee.name !== 't'
+			CallExpression(node) {
+				if (node.callee.type !== 'Identifier'
+					|| (node.callee.name !== 't' && node.callee.name !== 'n')
 				) {
 					return
 				}
 
-				if (node.raw?.match(/(?<=[^.])\.\.\.(?!\.)/)) {
-					context.report({
-						node,
-						message: 'Strings should ellipsis instead of triple dots',
-						fix(fixer) {
-							return fixer.replaceText(node, node.raw!.replaceAll(/(?<=[^.])\.\.\.(?!\.)/g, '…'))
-						},
-					})
+				for (const argument of node.arguments) {
+					if (argument.type !== 'Literal') {
+						continue
+					}
+
+					if (argument.raw?.match(/(?<=[^.])\.\.\.(?!\.)/)) {
+						context.report({
+							node,
+							messageId: 'shoudUseEllipsis',
+							fix(fixer) {
+								return fixer.replaceText(argument, argument.raw!.replaceAll(/(?<=[^.])\.\.\.(?!\.)/g, '…'))
+							},
+						})
+					}
 				}
 			},
 		}


### PR DESCRIPTION
- also check `n` method
- use `CallExpression` for visitor (there are more Literals than call expressions, so this should boost performance).