### PR TITLE
fix(globs): adjust globs for test related files

### DIFF
--- a/lib/globs.ts
+++ b/lib/globs.ts
@@ -8,8 +8,10 @@ export const GLOB_FILES_TESTING = [
 	'**/*.test.*',
 	'**/*.spec.*',
 	'**/*.cy.*',
-	'**/test',
-	'**/tests',
+	'**/test/**',
+	'**/tests/**',
+	'**/__tests__/**',
+	'**/__mocks__/**',
 ]
 
 /** Glob pattern for Typescript files */


### PR DESCRIPTION
This fixes issues where test setups and similar are not correctly seen as Node.js files with their globals.