### PR TITLE
chore: prepare release v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -->	
 # Changelog
 
-## [v9.0.0](https://github.com/nextcloud-libraries/eslint-config/tree/v9.0.0) (unreleased)
+## [v9.0.0](https://github.com/nextcloud-libraries/eslint-config/tree/v9.0.0) (2025-09-01)
 
 ### Breaking
 This package now is using ESLint v9 and requires ESLint flat configurations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/eslint-config",
-  "version": "9.0.0-rc.5",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/eslint-config",
-      "version": "9.0.0-rc.5",
+      "version": "9.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@eslint/json": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/eslint-config",
-  "version": "9.0.0-rc.5",
+  "version": "9.0.0",
   "description": "Eslint shared config for nextcloud apps and libraries",
   "keywords": [
     "eslint",


### PR DESCRIPTION
We are close to Nextcloud 32 release so we should stabilize here and ship with stable version released.

Also the apps will not revert anymore due to freezes (we will ship apps using this in 32 like firstrunwizard, photos or activities, similar with libraries).