### PR TITLE
feat(nextcloud-vue-plugin): deprecate additional exports

### DIFF
--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
@@ -150,6 +150,11 @@ describe('no-deprecated-exports', () => {
 					filename: '/a/src/component.vue',
 					errors: [{ messageId: 'deprecatedMixin' }],
 				},
+				{
+					code: '<script>import NcSettingsInputText from \'@nextcloud/vue/components/NcSettingsInputText\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedNcSettingsInputText' }],
+				},
 			],
 		})
 	})

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
@@ -155,6 +155,11 @@ describe('no-deprecated-exports', () => {
 					filename: '/a/src/component.vue',
 					errors: [{ messageId: 'deprecatedNcSettingsInputText' }],
 				},
+				{
+					code: '<script>import Tooltip from \'@nextcloud/vue/directives/Tooltip\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedTooltip' }],
+				},
 			],
 		})
 	})

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.test.ts
@@ -73,7 +73,7 @@ describe('no-deprecated-exports', () => {
 		})
 	})
 
-	test('no-deprecated-exports', () => {
+	test('no-deprecated-exports for dist syntax', () => {
 		vol.fromNestedJSON({
 			'/a': {
 				'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
@@ -124,6 +124,31 @@ describe('no-deprecated-exports', () => {
 					filename: '/a/src/component.vue',
 					errors: [{ messageId: 'deprecatedDist' }],
 					output: '<script>import isMobile from \'@nextcloud/vue/mixins/isMobile\'</script>',
+				},
+			],
+		})
+	})
+
+	test('no-deprecated-exports for removed content', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.31.0"}}',
+				src: { },
+			},
+		})
+		ruleTester.run('no-deprecated-exports', rule, {
+			valid: [
+				{
+					code: '<script>import NcButton from \'@nextcloud/vue/components/NcButton\'</script>',
+					filename: '/a/src/component.vue',
+				},
+			],
+
+			invalid: [
+				{
+					code: '<script>import isMobile from \'@nextcloud/vue/mixins/isMobile\'</script>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'deprecatedMixin' }],
 				},
 			],
 		})

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
@@ -26,6 +26,7 @@ const rule: Rule.RuleModule = {
 			outdatedVueLibrary: 'Installed @nextcloud/vue library is outdated and does not support all reported errors. Install latest compatible version',
 			deprecatedDist: 'Import from "@nextcloud/vue/dist" is deprecated',
 			deprecatedMixin: 'Mixins are no longer recommended by Vue. Consider using available alternatives',
+			deprecatedNcSettingsInputText: 'NcSettingsInputText is deprecated. Consider using available alternatives',
 		},
 	},
 
@@ -36,9 +37,25 @@ const rule: Rule.RuleModule = {
 		const oldPattern = '@nextcloud/vue/dist/([^/]+)/([^/.]+)'
 		const mixinPattern = '@nextcloud/vue/mixins/([^/.]+)'
 
+		const isVersionValidForNcSettingsInputText = versionSatisfies('8.31.0')
+		const patternForNcSettingsInputText = '@nextcloud/vue/components/NcSettingsInputText'
+
 		return {
 			ImportDeclaration: function(node) {
 				const importPath = node.source.value as string
+
+				const matchForNcSettingsInputText = importPath.match(new RegExp(patternForNcSettingsInputText))
+				if (matchForNcSettingsInputText) {
+					if (!isVersionValidForNcSettingsInputText) {
+						context.report({ node, messageId: 'outdatedVueLibrary' })
+						return
+					}
+
+					context.report({
+						node,
+						messageId: 'deprecatedNcSettingsInputText',
+					})
+				}
 
 				const mixinMatch = importPath.match(new RegExp(mixinPattern, 'i'))
 				if (mixinMatch) {

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-exports.ts
@@ -27,6 +27,7 @@ const rule: Rule.RuleModule = {
 			deprecatedDist: 'Import from "@nextcloud/vue/dist" is deprecated',
 			deprecatedMixin: 'Mixins are no longer recommended by Vue. Consider using available alternatives',
 			deprecatedNcSettingsInputText: 'NcSettingsInputText is deprecated. Consider using available alternatives',
+			deprecatedTooltip: 'Tooltip directive is deprecated. use native title attribute or NcPopover instead',
 		},
 	},
 
@@ -36,6 +37,9 @@ const rule: Rule.RuleModule = {
 
 		const oldPattern = '@nextcloud/vue/dist/([^/]+)/([^/.]+)'
 		const mixinPattern = '@nextcloud/vue/mixins/([^/.]+)'
+
+		const isVersionValidForTooltip = versionSatisfies('8.25.0')
+		const tooltipPattern = '@nextcloud/vue/directives/Tooltip'
 
 		const isVersionValidForNcSettingsInputText = versionSatisfies('8.31.0')
 		const patternForNcSettingsInputText = '@nextcloud/vue/components/NcSettingsInputText'
@@ -67,6 +71,19 @@ const rule: Rule.RuleModule = {
 					context.report({
 						node,
 						messageId: 'deprecatedMixin',
+					})
+				}
+
+				const tooltipMatch = importPath.match(new RegExp(tooltipPattern))
+				if (tooltipMatch) {
+					if (!isVersionValidForTooltip) {
+						context.report({ node, messageId: 'outdatedVueLibrary' })
+						return
+					}
+
+					context.report({
+						node,
+						messageId: 'deprecatedTooltip',
 					})
 				}
 


### PR DESCRIPTION
- All of them are not provided with Vue3 already, but should be a good indicator for Vue 2 to migrate
