### PR TITLE
feat(nextcloud-vue-plugin): deprecate additional props

### DIFF
--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
@@ -300,6 +300,11 @@ describe('no-deprecated-props', () => {
 					filename: '/a/src/component.vue',
 					errors: [{ messageId: 'removeLimitWidth' }],
 				},
+				{
+					code: '<template><NcButton :to="toObject" exact @click="handle">Hello</NcButton></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'removeExact' }],
+				},
 			],
 		})
 	})

--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.ts
@@ -33,6 +33,7 @@ export default {
 			useArrowEndInstead: 'Using `arrow-right` is deprecated - use `arrow-end` instead',
 			removeAriaHidden: 'Using `aria-hidden` is deprecated - remove prop from components, otherwise root element will inherit incorrect attribute.',
 			removeLimitWidth: 'Using `limit-width` is deprecated - remove prop from components, otherwise root element will inherit incorrect attribute.',
+			removeExact: 'Using `exact` is deprecated - consult Vue Router documentation for alternatives.',
 			useCloseButtonOutsideInstead: 'Using `close-button-contained` is deprecated - use `close-button-outside` instead',
 		},
 	},
@@ -346,6 +347,28 @@ export default {
 				context.report({
 					node,
 					messageId: 'removeLimitWidth',
+				})
+			},
+
+			'VElement VAttribute:has(VIdentifier[name="exact"])': function(node) {
+				if (![
+					'ncactionrouter',
+					'ncappnavigationitem',
+					'ncbreadcrumb',
+					'ncbutton',
+					'nclistitem',
+				].includes(node.parent.parent.name)) {
+					return
+				}
+
+				if (!isVue3Valid) {
+					// Do not throw for v8.X.X
+					return
+				}
+
+				context.report({
+					node,
+					messageId: 'removeExact',
 				})
 			},
 		})


### PR DESCRIPTION
Ref #1001

#### NcTextField
- The value `'arrowRight'` for the `trailingButtonIcon` property was deprecated is now removed in favor of `arrowEnd`
- v8.28.0, #7002

#### NcDateTimePicker
- The `lang` object property was replaced with the `locale` string property
- not backported, #6651

#### NcSettingsSection
- The `limitWidth` was removed (the content is now always limited width)
- 8.13.0, #5604

#### NcModal
- The `closeButtonContained` was removed in favor of `closeButtonOutside`
- 8.32.0, [#7553](https://github.com/nextcloud-libraries/nextcloud-vue/pull/7553) ⚠️ NOT RELEASED 

#### RouterLink
- The `exact` prop, previously used by `router-link` components, was removed
- not backported, 9.0.0-alpha