### PR TITLE
feat(nextcloud-vue-plugin): deprecate NcPopover props

### DIFF
--- a/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
+++ b/lib/plugins/nextcloud-vue/rules/no-deprecated-props.test.ts
@@ -333,6 +333,30 @@ describe('no-deprecated-props', () => {
 					errors: [{ messageId: 'useModelValueInsteadChecked' }],
 					output: '<template><NcCheckboxRadioSwitch v-model="isChecked" /></template>',
 				},
+				{
+					code: '<template><NcTextField value="input" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useModelValueInsteadValue' }],
+					output: '<template><NcTextField model-value="input" /></template>',
+				},
+				{
+					code: '<template><NcTextField :value="input" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useModelValueInsteadValue' }],
+					output: '<template><NcTextField :model-value="input" /></template>',
+				},
+				{
+					code: '<template><NcTextField :value.sync="input" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useModelValueInsteadValue' }],
+					output: '<template><NcTextField v-model="input" /></template>',
+				},
+				{
+					code: '<template><NcTextField v-model:value="input" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useModelValueInsteadValue' }],
+					output: '<template><NcTextField v-model="input" /></template>',
+				},
 			],
 		})
 	})


### PR DESCRIPTION
Ref #1001 

Lat chunk of deprecated props:
- `closeOnClickOutside` prop was replaced with `noCloseOnClickOutside`
- `checked` prop was replaced with `modelValue`
- `value` prop was replaced with `modelValue`

Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>