### PR TITLE
fix(plugin:nextcloud-vue): use resolved dependency for detecting nextcloud-vue version

### DIFF
--- a/lib/plugins/nextcloud-vue/utils/lib-version-parser.test.ts
+++ b/lib/plugins/nextcloud-vue/utils/lib-version-parser.test.ts
@@ -2,176 +2,86 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 import { fs, vol } from 'memfs'
-import { join } from 'node:path'
-import { afterAll, afterEach, beforeAll, describe, expect, it, test, vi } from 'vitest'
-import {
-	createLibVersionValidator,
-	findPackageJsonDir,
-	isFile,
-	sanitizeTargetVersion,
-} from './lib-version-parser.ts'
+import { beforeEach } from 'node:test'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { clearCache, createLibVersionValidator } from './lib-version-parser.ts'
 
 vi.mock('node:fs', () => fs)
 
-describe('version-parser', () => {
+describe('createLibVersionValidator', () => {
 	beforeAll(() => vol.fromNestedJSON({
 		[__dirname]: {},
 		[__filename]: '...',
 	}))
+	beforeEach(() => clearCache())
 	afterAll(() => vol.reset())
 
-	test('isFile', () => {
-		expect(isFile(__dirname)).toBe(false)
-		expect(isFile(__filename)).toBe(true)
-		expect(isFile(join(__dirname, 'does-not-exists.invalid'))).toBe(false)
-	})
-
-	test('sanitizeTargetVersion', () => {
-		expect(sanitizeTargetVersion('^23.0.0')).toBe('23.0.0')
-		expect(sanitizeTargetVersion('25.0')).toBe('25.0.0')
-		expect(sanitizeTargetVersion('25.0.1')).toBe('25.0.1')
-
-		try {
-			const output = sanitizeTargetVersion('a.b.c')
-			expect(output).toBe('Should not be reached')
-		} catch (e) {
-			expect(e.message).toMatch(/Invalid comparator/)
-		}
-
-		try {
-			const output = sanitizeTargetVersion('25.0.0.1')
-			expect(output).toBe('Should not be reached')
-		} catch (e) {
-			expect(e.message).toMatch(/Invalid comparator/)
-		}
-	})
-
-	describe('findPackageJsonDir', () => {
-		afterEach(() => vol.reset())
-
-		it('finds a package.json if provided', () => {
-			vol.fromNestedJSON({
-				'/a': {
-					'package.json': '...',
-					src: {},
-				},
-			})
-
-			expect(findPackageJsonDir('/a/src')).toBe('/a')
+	it.for`
+	version     | expected
+	------------|---------
+	${'8.22.0'} | ${false}
+	${'8.23.0'} | ${false}
+	${'8.23.1'} | ${false}
+	${'8.24.0'} | ${false}
+	${'9.0.0'}  | ${false}
+	`('returns false without nextcloud/vue in dependencies', ({ version, expected }) => {
+		const fn = createLibVersionValidator({
+			cwd: '',
+			physicalFilename: '/a/src/b.js',
+		}, () => {
+			throw new Error('not found', { cause: 'ERR_MODULE_NOT_FOUND' })
 		})
+		expect(fn(version)).toBe(expected)
+	})
 
-		it('finds a package.json if provided on lower directory', () => {
-			vol.fromNestedJSON({
-				'/a': {
-					'package.json': '...',
-					src: {
-						b: {
-							c: {},
+	it('works with physical filename', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				node_modules: {
+					'@nextcloud': {
+						vue: {
+							'package.json': '{"version": "8.23.1"}',
 						},
 					},
 				},
-			})
-
-			expect(findPackageJsonDir('/a/src/b/c')).toBe('/a')
+				src: {},
+			},
 		})
-
-		it('returns undefined if not found', () => {
-			vol.fromNestedJSON({
-				'/a/src/b/c': {},
-			})
-
-			expect(findPackageJsonDir('/a/src/b/c')).toBe(undefined)
-		})
+		const fn = createLibVersionValidator({
+			cwd: '',
+			physicalFilename: '/a/src/b.js',
+		}, () => 'file:///a/node_modules/@nextcloud/vue/dist/index.js')
+		expect(fn('8.22.0')).toBe(true)
+		expect(fn('8.23.0')).toBe(true)
+		expect(fn('8.23.1')).toBe(true)
+		expect(fn('8.24.0')).toBe(false)
+		expect(fn('9.0.0')).toBe(false)
 	})
 
-	describe('createLibVersionValidator', () => {
-		it('no config', () => {
-			const fn = createLibVersionValidator({
-				cwd: '',
-				physicalFilename: '',
-			})
-			expect(fn('8.22.0')).toBe(false)
-			expect(fn('8.23.0')).toBe(false)
-			expect(fn('8.23.1')).toBe(false)
-			expect(fn('8.24.0')).toBe(false)
-			expect(fn('9.0.0')).toBe(false)
+	it('works with cwd', () => {
+		vol.fromNestedJSON({
+			'/a': {
+				node_modules: {
+					'@nextcloud': {
+						vue: {
+							'package.json': '{"version": "8.23.1"}',
+						},
+					},
+				},
+				src: {},
+			},
 		})
+		const fn = createLibVersionValidator({
+			cwd: '/a',
+			physicalFilename: 'src/b.js',
+		}, () => 'file:///a/node_modules/@nextcloud/vue/dist/index.js')
 
-		describe('package.json', () => {
-			afterEach(() => vol.reset())
-
-			it('returns false without nextcloud/vue in dependencies', () => {
-				vol.fromNestedJSON({
-					'/a': {
-						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{}}',
-						src: { },
-					},
-				})
-				const fn = createLibVersionValidator({
-					cwd: '',
-					physicalFilename: '/a/src/b.js',
-				})
-				expect(fn('8.22.0')).toBe(false)
-				expect(fn('8.23.0')).toBe(false)
-				expect(fn('8.23.1')).toBe(false)
-				expect(fn('8.24.0')).toBe(false)
-				expect(fn('9.0.0')).toBe(false)
-			})
-
-			it('works with physical filename', () => {
-				vol.fromNestedJSON({
-					'/a': {
-						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
-						src: { },
-					},
-				})
-				const fn = createLibVersionValidator({
-					cwd: '',
-					physicalFilename: '/a/src/b.js',
-				})
-				expect(fn('8.22.0')).toBe(true)
-				expect(fn('8.23.0')).toBe(true)
-				expect(fn('8.23.1')).toBe(true)
-				expect(fn('8.24.0')).toBe(false)
-				expect(fn('9.0.0')).toBe(false)
-			})
-
-			it('works with cwd', () => {
-				vol.fromNestedJSON({
-					'/a': {
-						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.23.1"}}',
-						src: { },
-					},
-				})
-				const fn = createLibVersionValidator({
-					cwd: '/a',
-					physicalFilename: 'src/b.js',
-				})
-				expect(fn('8.22.0')).toBe(true)
-				expect(fn('8.23.0')).toBe(true)
-				expect(fn('8.23.1')).toBe(true)
-				expect(fn('8.24.0')).toBe(false)
-				expect(fn('9.0.0')).toBe(false)
-			})
-
-			it('works with several dependency sources', () => {
-				vol.fromNestedJSON({
-					'/a': {
-						'package.json': '{"name": "my-app","version": "0.1.0","dependencies":{"@nextcloud/vue":"^8.24.0"},"devDependencies":{"@nextcloud/vue":"^8.24.0"},"peerDependencies":{"@nextcloud/vue":"^8.23.1"}}',
-						src: { },
-					},
-				})
-				const fn = createLibVersionValidator({
-					cwd: '/a',
-					physicalFilename: 'src/b.js',
-				})
-				expect(fn('8.22.0')).toBe(true)
-				expect(fn('8.23.0')).toBe(true)
-				expect(fn('8.23.1')).toBe(true)
-				expect(fn('8.24.0')).toBe(false)
-				expect(fn('9.0.0')).toBe(false)
-			})
-		})
+		expect(fn('8.22.0')).toBe(true)
+		expect(fn('8.23.0')).toBe(true)
+		expect(fn('8.23.1')).toBe(true)
+		expect(fn('8.24.0')).toBe(false)
+		expect(fn('9.0.0')).toBe(false)
 	})
 })

--- a/lib/plugins/nextcloud-vue/utils/lib-version-parser.ts
+++ b/lib/plugins/nextcloud-vue/utils/lib-version-parser.ts
@@ -2,60 +2,15 @@
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { lstatSync, readFileSync } from 'node:fs'
-import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
-import { gte, minVersion, valid } from 'semver'
+import { readFileSync } from 'node:fs'
+import { isAbsolute, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { gte } from 'semver'
 
 /**
  * Cached map of paths: Reco <path_to_package.json, validator>
  */
-const cachedMap: Record<string, (version: string) => boolean> = {}
-
-/**
- * Check if a given path exists and is a file
- *
- * @param filePath The path
- */
-export function isFile(filePath: string): boolean {
-	const stats = lstatSync(filePath, { throwIfNoEntry: false })
-	return stats !== undefined && stats.isFile()
-}
-
-/**
- * Find the path of nearest `package.json` relative to given path
- *
- * @param currentPath Path to lookup
- * @return Either the full path where `package.json` is located or `undefined` if no found
- */
-export function findPackageJsonDir(currentPath: string): string | undefined {
-	for (const cachedDirPath of Object.keys(cachedMap)) {
-		if (currentPath.startsWith(cachedDirPath)) {
-			return cachedDirPath
-		}
-	}
-	while (currentPath && currentPath !== sep) {
-		if (isFile(join(currentPath, 'package.json'))) {
-			return currentPath
-		}
-		currentPath = resolve(currentPath, '..')
-	}
-	return undefined
-}
-
-/**
- * Make sure that versions like '25' can be handled by semver
- *
- * @param version The pure version string
- * @return Sanitized version string
- */
-export function sanitizeTargetVersion(version: string): string {
-	const sanitizedVersion = minVersion(version)?.version
-	// now version should look like '23.0.0'
-	if (!valid(sanitizedVersion)) {
-		throw Error(`[@nextcloud/eslint-plugin] Invalid target version ${version} found`)
-	}
-	return sanitizedVersion
-}
+const cachedMap = new Map<string, (version: string) => boolean>()
 
 /**
  * Create a callback that takes a version number and checks if the version
@@ -64,39 +19,36 @@ export function sanitizeTargetVersion(version: string): string {
  * @param options Options
  * @param options.cwd The current working directory
  * @param options.physicalFilename The real filename where ESLint is linting currently
+ * @param importResolve Optional custom import resolver function (for testing purposes)
  * @return Function validator, return a boolean whether current version satisfies minimal required for the rule
  */
-export function createLibVersionValidator({ cwd, physicalFilename }): ((version: string) => boolean) {
-	// Try to find package.json and parse the supported version
-	// Current working directory, either the filename (can be empty) or the cwd property
-	const currentDirectory = isAbsolute(physicalFilename)
-		? resolve(dirname(physicalFilename))
-		: dirname(resolve(cwd, physicalFilename))
+export function createLibVersionValidator({ cwd, physicalFilename }, importResolve = import.meta.resolve): ((version: string) => boolean) {
+	// Try to find package.json of the nextcloud-vue package
+	const sourceFile = isAbsolute(physicalFilename)
+		? resolve(physicalFilename)
+		: resolve(cwd, physicalFilename)
 
-	// The nearest package.json
-	const packageJsonDir = findPackageJsonDir(currentDirectory)
-	if (!packageJsonDir) {
-		// Skip the rule
-		return () => false
-	} else if (cachedMap[packageJsonDir]) {
-		return cachedMap[packageJsonDir]
-	}
-
-	const json = JSON.parse(readFileSync(join(packageJsonDir, 'package.json'), 'utf-8'))
-	const libVersions = [
-		json?.dependencies?.['@nextcloud/vue'],
-		json?.devDependencies?.['@nextcloud/vue'],
-		json?.peerDependencies?.['@nextcloud/vue'],
-	]
-		.filter((version) => typeof version === 'string' && !!version)
-		.map(sanitizeTargetVersion)
-		.sort((a, b) => gte(a, b) ? 1 : -1)
-
-	if (!libVersions.length) {
-		// Skip the rule
+	let packageJsonDir: string
+	try {
+		const modulePath = fileURLToPath(importResolve('@nextcloud/vue', pathToFileURL(sourceFile)))
+		const idx = modulePath.lastIndexOf('/dist/')
+		packageJsonDir = modulePath.substring(0, idx)
+	} catch {
 		return () => false
 	}
 
-	// Return, whether given version satisfies minimal version from dependencies
-	return (version: string) => gte(libVersions[0], version)
+	if (!cachedMap[packageJsonDir]) {
+		const json = JSON.parse(readFileSync(join(packageJsonDir, 'package.json'), 'utf-8'))
+		const libVersion = json.version
+		cachedMap[packageJsonDir] = (version: string) => gte(libVersion, version)
+	}
+
+	return cachedMap[packageJsonDir]
+}
+
+/**
+ * Clear the module cache
+ */
+export function clearCache() {
+	cachedMap.clear()
 }


### PR DESCRIPTION
This fixes multiple issues:
- If package.json is not pinned but we already use an updated version (e.g. package-lock.json is only updated).
- If the package.json is not in the root directory (e.g. mono repos etc).