### PR TITLE
feat(vue): add vue/component-options-name-casing with PascalCase

### DIFF
--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -52,11 +52,11 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 			files: GLOB_FILES_VUE,
 			name: 'nextcloud/vue/rules',
 			rules: {
-				// PascalCase components names for vuejs
-				'vue/component-name-in-template-casing': [
-					'error',
-					'PascalCase',
-				],
+				// PascalCase components names in template tag names
+				'vue/component-name-in-template-casing': ['error', 'PascalCase'],
+				// Also in registration
+				'vue/component-options-name-casing': ['error', 'PascalCase'],
+
 				// space before self-closing elements
 				'vue/html-closing-bracket-spacing': 'error',
 				// no ending html tag on a new line


### PR DESCRIPTION
- Ref: https://github.com/nextcloud-libraries/eslint-config/issues/1219
- Add a rule for what we have de-facto

```vue
<script>
import NcComponent from './NcComponent.vue'

export default {
	name: 'MyApp',

	components: {
		NcComponent, // ✅ Good
		'nc-component': NcComponent, // ❌ Bad
	},
}
</script>
```