### PR TITLE
feat(vue3): force camelCase for events in <script>

### DIFF
--- a/lib/configs/vue2.ts
+++ b/lib/configs/vue2.ts
@@ -26,12 +26,12 @@ export function vue2(option: ConfigOptions): Linter.Config[] {
 
 		{
 			rules: {
-			// custom event naming convention
+				// Force kebab-case for custom event name definitions (recommended by Vue 2 documentation)
 				'vue/custom-event-name-casing': [
 					'error',
 					'kebab-case',
 					{
-						// allows custom xxxx:xxx events formats
+						// Allow namespace formats namespace:event
 						ignores: ['/^[a-z]+(?:-[a-z]+)*:[a-z]+(?:-[a-z]+)*$/u'],
 					},
 				],

--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -28,6 +28,15 @@ export function vue3(options: ConfigOptions): Linter.Config[] {
 		{
 			files: GLOB_FILES_VUE,
 			rules: {
+				// Force camelCase for custom event name definitions (recommended by Vue 3 documentation and consistent with JS)
+				'vue/custom-event-name-casing': [
+					'error',
+					'camelCase',
+					{
+						// Allow namespace formats namespace:event
+						ignores: ['/^[a-z]+:[a-z]+$/iu'],
+					},
+				],
 				// Deprecated thus we should not use it
 				'vue/no-deprecated-delete-set': 'error',
 				// When using script-setup the modern approach should be used


### PR DESCRIPTION
- ref: https://github.com/nextcloud-libraries/eslint-config/issues/1219
- Add a rule for what we have de-facto

```vue
<script>
export default {
	name: 'MyApp',

	emits: [
		'componentEvent', // ✅ Good
		'component-event', // ❌ Bad
	],
}
</script>

<template>
	<button @click="$emit('componentEvent')" /> <!-- ✅ Good -->
	<button @click="$emit('component-event')" /> <!-- ❌ Bad -->
</template>
```