### PR TITLE
feat(vue3): force camelCase for events in <template>

### DIFF
--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -37,6 +37,9 @@ export function vue3(options: ConfigOptions): Linter.Config[] {
 						ignores: ['/^[a-z]+:[a-z]+$/iu'],
 					},
 				],
+				// Also force camelCase for events in template for consistency with <script>
+				'vue/v-on-event-hyphenation': ['error', 'never', { autofix: true }],
+
 				// Deprecated thus we should not use it
 				'vue/no-deprecated-delete-set': 'error',
 				// When using script-setup the modern approach should be used


### PR DESCRIPTION
- ref: https://github.com/nextcloud-libraries/eslint-config/issues/1219
- Unlike previous change, this is more significant, going against the default vue recommendation (but still allowed by the documentation)
- 
```vue
<template>
	<!-- ✅ Good -->
	<MyComponent @customEvent="handleEvent" />
	<!-- ✅ Also fine -->
	<MyComponent @namespace:customEvent="handleEvent" />

	!-- ❌ Bad -->
	<MyComponent @custom-event="handleEvent" />
</template>
```