### PR TITLE
feat(vue3): force camelCase for slot names

### DIFF
--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -39,6 +39,11 @@ export function vue3(options: ConfigOptions): Linter.Config[] {
 				],
 				// Also force camelCase for events in template for consistency with <script>
 				'vue/v-on-event-hyphenation': ['error', 'never', { autofix: true }],
+				// Also for slots
+				// Changing case is breaking for component users.
+				// For libraries it may result in a breaking change. Warn to prevent unintended breaking change.
+				// TODO: allow namespace:slotName format like in events
+				'vue/slot-name-casing': [options.isLibrary ? 'warn' : 'error', 'camelCase'],
 
 				// Deprecated thus we should not use it
 				'vue/no-deprecated-delete-set': 'error',


### PR DESCRIPTION
- ref: https://github.com/nextcloud-libraries/eslint-config/issues/1219
- camelCase in slot definition (`<slot name="myName" />`)
- No changes for existing usages (`<template #slot-kebab-name />`)
- Warn on libraries to avoid unintended breaking changes
- Error on apps

```vue
<script setup lang="ts">
import type { Slot } from 'vue'

defineSlots<{
	mySlot: Slot // ✅ Good 
	'my-slot': Slot // ❌ Bad
}>()
</script>

<template>
	<!-- ✅ Good -->
	<slot name="mySlot" />

	!-- ❌ Bad -->
	<slot name="my-slot" />
</template>
```