### PR TITLE
feat(vue3): force camelCase for props in template

### DIFF
--- a/lib/configs/vue3.ts
+++ b/lib/configs/vue3.ts
@@ -28,6 +28,8 @@ export function vue3(options: ConfigOptions): Linter.Config[] {
 		{
 			files: GLOB_FILES_VUE,
 			rules: {
+				// Force camelCase in props/attrs for consistency with <script> and prevent tooling issues
+				'vue/attribute-hyphenation': ['error', 'never'],
 				// Force camelCase for custom event name definitions (recommended by Vue 3 documentation and consistent with JS)
 				'vue/custom-event-name-casing': [
 					'error',
@@ -37,9 +39,9 @@ export function vue3(options: ConfigOptions): Linter.Config[] {
 						ignores: ['/^[a-z]+:[a-z]+$/iu'],
 					},
 				],
-				// Also force camelCase for events in template for consistency with <script>
+				// Force camelCase for events in template for consistency with <script>
 				'vue/v-on-event-hyphenation': ['error', 'never', { autofix: true }],
-				// Also for slots
+				// Force camelCase for slot names.
 				// Changing case is breaking for component users.
 				// For libraries it may result in a breaking change. Warn to prevent unintended breaking change.
 				// TODO: allow namespace:slotName format like in events


### PR DESCRIPTION
- ref: https://github.com/nextcloud-libraries/eslint-config/issues/1219
- Auto-fixable
- Quite a huge changer against the default Vue recommendation
- I'm not sure about `aria-*` and `data-*` ignore

```vue
<script setup>
const myShortcut = 'value'
</script>

<template>
	<!-- ✅ Good -->
	<MyComponent myProp="value" :myShortcut myBoolean />
	<!-- ✅ Also fine -->
	<MyComponent aria-label="label" data-attr="value" />

	!-- ❌ Bad -->
	<MyComponent my-prop="value" :my-shortcut my-boolean />
</template>
```