### PR TITLE
fix: pin `eslint-plugin-vue` to 10.6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-plugin-antfu": "^3.1.3",
         "eslint-plugin-jsdoc": "^62.0.0",
         "eslint-plugin-perfectionist": "^5.3.1",
-        "eslint-plugin-vue": "^10.6.2",
+        "eslint-plugin-vue": "~10.6.2",
         "fast-xml-parser": "^5.3.3",
         "globals": "^17.0.0",
         "semver": "^7.7.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-antfu": "^3.1.3",
     "eslint-plugin-jsdoc": "^62.0.0",
     "eslint-plugin-perfectionist": "^5.3.1",
-    "eslint-plugin-vue": "^10.6.2",
+    "eslint-plugin-vue": "~10.6.2",
     "fast-xml-parser": "^5.3.3",
     "globals": "^17.0.0",
     "semver": "^7.7.3",


### PR DESCRIPTION
Ref: https://github.com/vuejs/eslint-plugin-vue/pull/2916#issuecomment-3768816322

The utils are no longer exported, and unless this becomes a ESLint language plugin[1] we cannot really add our own Vue Template rules.

[1]: https://github.com/vuejs/eslint-plugin-vue/issues/2778