### PR TITLE
fix(imports): no newline inside import statements

### DIFF
--- a/lib/configs/imports.ts
+++ b/lib/configs/imports.ts
@@ -106,7 +106,7 @@ export function imports(options: ConfigOptions): Linter.Config[] {
 function createSortingConfig(type: 'export' | 'import') {
 	return {
 		type: 'natural',
-		newlinesBetween: 1,
+		newlinesBetween: 0,
 		partitionByNewLine: false,
 		groups: [
 			`type-${type}`,

--- a/tests/fixtures/codestyle/input/exports.ts
+++ b/tests/fixtures/codestyle/input/exports.ts
@@ -4,6 +4,8 @@ export {
 	afoo,
 } from './my/module.ts'
 
+export { zbar, type a } from './my/module.ts'
+
 const z = ''
 const b = ''
 

--- a/tests/fixtures/codestyle/input/imports.ts
+++ b/tests/fixtures/codestyle/input/imports.ts
@@ -21,3 +21,13 @@ import 'some-sideeffect'
 
 import type { AssertPredicate } from 'node:assert'
 import style from './my.module.css'
+
+import { type Config, createConfig } from './config.ts';
+
+import {
+	type Bear,
+	type Elefant,
+	createBear,
+	type Zoo,
+	createZoo,
+} from './zoo.ts';

--- a/tests/fixtures/codestyle/output/exports.ts
+++ b/tests/fixtures/codestyle/output/exports.ts
@@ -1,9 +1,10 @@
 export {
 	type a,
-
 	afoo,
 	zbar,
 } from './my/module.ts'
+
+export { type a, zbar } from './my/module.ts'
 
 const z = ''
 const b = ''

--- a/tests/fixtures/codestyle/output/imports.ts
+++ b/tests/fixtures/codestyle/output/imports.ts
@@ -16,6 +16,14 @@ import IconBellRingOutline from 'vue-material-design-icons/BellRingOutline.vue'
 import SettingsFormGroup from './components/SettingsFormGroup.vue'
 import { a, y, z } from '../../../constants.js'
 import { useAppConfigStore } from './appConfig.store.ts'
+import { type Config, createConfig } from './config.ts'
+import {
+	type Bear,
+	type Elefant,
+	type Zoo,
+	createBear,
+	createZoo,
+} from './zoo.ts'
 
 import 'some-sideeffect'
 import style from './my.module.css'


### PR DESCRIPTION
Fixes #1378.

Remove newlines from within import and export statements.
`perfectionist/sort-named-imports` creates newlines between groups
even if the import is on a single line.

The resulting output conflicts with codestyle rules
leading to circular fixes.

Newlines were used to separate type imports / exports from normal ones.
The groups can clearly be destinguished based on the presence of the `type` keyword.
