### PR TITLE
chore: remove EOL Node version and add new future LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "typescript-eslint": "^8.58.2"
       },
       "devDependencies": {
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.12.2",
         "@types/semver": "^7.7.1",
         "eslint": "^10.2.0",
         "memfs": "^4.57.1",
@@ -1126,13 +1126,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/semver": {
@@ -3257,9 +3257,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,14 @@
         "typescript-eslint": "^8.61.1"
       },
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.0.0",
         "@types/semver": "^7.7.1",
         "eslint": "^10.5.0",
         "memfs": "^4.57.7",
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": "^20.19 || ^22.13 || ^24"
+        "node": "^22.13 || ^24 || >=26"
       },
       "peerDependencies": {
         "eslint": ">=10"
@@ -1156,13 +1156,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/semver": {
@@ -3320,9 +3320,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript-eslint": "^8.58.2"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.12.2",
     "@types/semver": "^7.7.1",
     "eslint": "^10.2.0",
     "memfs": "^4.57.1",
@@ -68,7 +68,7 @@
     "eslint": ">=10"
   },
   "engines": {
-    "node": "^20.19 || ^22.13 || ^24"
+    "node": "^22.13 || ^24 || >=26"
   },
   "devEngines": {
     "packageManager": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript-eslint": "^8.61.1"
   },
   "devDependencies": {
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "@types/semver": "^7.7.1",
     "eslint": "^10.5.0",
     "memfs": "^4.57.7",
@@ -68,7 +68,7 @@
     "eslint": ">=10"
   },
   "engines": {
-    "node": "^20.19 || ^22.13 || ^24"
+    "node": "^22.13 || ^24 || >=26"
   },
   "devEngines": {
     "packageManager": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,12 @@
 		"resolveJsonModule": true,
 		"moduleResolution": "NodeNext",
 		"module": "NodeNext",
-		"target": "ES2022",
-		"lib": ["ES2022"],
+		"target": "es2024",
+		"lib": ["ES2024"],
 		"outDir": "./dist",
 		"rootDir": "lib/",
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"types": ["node"]
 	},
 	"include": [
 		"lib"


### PR DESCRIPTION
Node 20 is EOL since 2026-04-22.
Node 26 is the current Node version and will become the next LTS. Additionally with Node 27 the release schema changed, so every Node version >= 26 will be a LTS.