### PR TITLE
fix(vue): enforce stricter Vue rules

### DIFF
--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -141,7 +141,11 @@ export function vue(options: ConfigOptions): Linter.Config[] {
 				'vue/padding-line-between-blocks': 'error',
 				// Prefer separated static and dynamic class attributes
 				'vue/prefer-separate-static-class': 'error',
+				// For consistent layout of the template
+				'vue/attributes-order': 'error',
 				// For consistent layout of components
+				'vue/order-in-components': 'error',
+				// For consistent layout of script-setup components
 				'vue/define-macros-order': [
 					'error',
 					{


### PR DESCRIPTION
- make attribute order an error instead of warning (`v-show` before normal attributes)
- make components order an error instead of warning (props -> emits -> setup)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
