### PR TITLE
fix: `no-deprecated-library-*` rules incorrectly behave for `nextcloud/vue` syntax

### DIFF
--- a/lib/plugins/nextcloud/rules/no-deprecated-library-exports.test.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-exports.test.ts
@@ -105,8 +105,7 @@ describe('no-deprecated-library-exports', () => {
 				{
 					code: '<script>import isMobile from \'@nextcloud/vue/dist/Mixins/isMobile.js\'</script>',
 					filename: '/a/src/component.vue',
-					errors: [{ messageId: 'deprecatedDist' }],
-					output: '<script>import isMobile from \'@nextcloud/vue/mixins/isMobile\'</script>',
+					errors: [{ messageId: 'deprecatedMixin' }],
 				},
 			],
 		})

--- a/lib/plugins/nextcloud/rules/no-deprecated-library-exports.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-exports.ts
@@ -32,7 +32,11 @@ const rule: Rule.RuleModule = {
 		const isVersionValidForDist = versionSatisfies('8.23.0')
 
 		const oldPattern = '@nextcloud/vue/dist/([^/]+)/([^/.]+)'
-		const mixinPattern = '@nextcloud/vue/mixins/([^/.]+)'
+		// Matches both the legacy `dist/Mixins/*` path and a bare `mixins/*` path.
+		// There is no clean `@nextcloud/vue/mixins/*` subpath export (only components,
+		// composables, directives and functions), so mixins must be migrated to
+		// composables rather than have their import path rewritten.
+		const mixinPattern = '@nextcloud/vue/(?:dist/)?mixins/([^/.]+)'
 
 		const isVersionValidForTooltip = versionSatisfies('8.25.0')
 		const tooltipPattern = '@nextcloud/vue/directives/Tooltip'
@@ -88,6 +92,11 @@ const rule: Rule.RuleModule = {
 				if (match) {
 					if (!isVersionValidForDist) {
 						context.report({ node, messageId: 'outdatedVueLibrary' })
+						return
+					}
+
+					// Mixins removed in v9 and already reported as `deprecatedMixin`
+					if (match[1].toLowerCase() === 'mixins') {
 						return
 					}
 

--- a/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
@@ -33,7 +33,7 @@ export default {
 			useNoFocusTrapInstead: 'Using `focus-trap` is deprecated - use `no-focus-trap` instead',
 			useKeepOpenInstead: 'Using `close-on-select` is deprecated - use `keep-open` instead',
 			useNcSelectUsersInstead: 'Using `user-select` is deprecated - use `NcSelectUsers` component instead',
-			useArrowEndInstead: 'Using `arrow-right` is deprecated - use `arrow-end` instead',
+			useArrowEndInstead: 'Using `arrowRight` as `trailing-button-icon` value is deprecated - use `arrowEnd` instead',
 			removeAriaHidden: 'Using `aria-hidden` is deprecated - remove prop from components, otherwise root element will inherit incorrect attribute.',
 			removeLimitWidth: 'Using `limit-width` is deprecated - remove prop from components, otherwise root element will inherit incorrect attribute.',
 			removeExact: 'Using `exact` is deprecated - consult Vue Router documentation for alternatives.',

--- a/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
@@ -54,7 +54,7 @@ export default {
 		const isDateTimePickerFormatValid = versionSatisfies('8.25.0') // #6738
 		const isNcSelectKeepOpenValid = versionSatisfies('8.25.0') // #6791
 		const isNcPopoverNoFocusTrapValid = versionSatisfies('8.26.0') // #6808
-		const isNcSelectUsersValid = versionSatisfies('8.27.1') // #7032
+		const isNcSelectUsersValid = versionSatisfies('8.25.0') // #6791
 		const isNcTextFieldArrowEndValid = versionSatisfies('8.28.0') // #7002
 		const isCloseButtonOutsideValid = versionSatisfies('8.32.0') // #7553
 
@@ -374,7 +374,7 @@ export default {
 			},
 
 			'VElement[name="ncsettingssection"] VAttribute:has(VIdentifier[name="limit-width"])': function(node: AST.VAttribute | AST.VDirective) {
-				// This was deprecated in 8.13.0 (Nextcloud 30+), before first supported version by plugin
+				// This was deprecated in 8.12.0 (Nextcloud 30+), before first supported version by plugin
 				context.report({
 					node,
 					messageId: 'removeLimitWidth',

--- a/lib/plugins/nextcloud/utils/lib-version-parser.ts
+++ b/lib/plugins/nextcloud/utils/lib-version-parser.ts
@@ -37,13 +37,13 @@ export function createLibVersionValidator({ cwd, physicalFilename }, importResol
 		return () => false
 	}
 
-	if (!cachedMap[packageJsonDir]) {
+	if (!cachedMap.has(packageJsonDir)) {
 		const json = JSON.parse(readFileSync(join(packageJsonDir, 'package.json'), 'utf-8'))
 		const libVersion = json.version
-		cachedMap[packageJsonDir] = (version: string) => gte(libVersion, version)
+		cachedMap.set(packageJsonDir, (version: string) => gte(libVersion, version))
 	}
 
-	return cachedMap[packageJsonDir]
+	return cachedMap.get(packageJsonDir)!
 }
 
 /**


### PR DESCRIPTION
Minor adjustments for `nextcloud/vue` deprecation rules (due to changes made upstream and former mistakes):
- converted path `@nextcloud/vue/mixins/*` does not exist in both v8 and v9 - should throw error, not replace
- some deprecations were marked for incorrect versions
- arrowRight was a value (not a prop) and always camelCase
- cachedMap is a Map(), but methods weren't used


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
	- Assisted-by: ClaudeCode:claude-opus-4-8
