### PR TITLE
fix(no-deprecated-library-props): support win32 filesystem and different `@nextcloud/vue` directory structures

### DIFF
--- a/lib/plugins/nextcloud/utils/lib-version-parser.test.ts
+++ b/lib/plugins/nextcloud/utils/lib-version-parser.test.ts
@@ -4,11 +4,20 @@
  */
 
 import { fs, vol } from 'memfs'
+import { findPackageJSON } from 'node:module'
 import { beforeEach } from 'node:test'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { clearCache, createLibVersionValidator } from './lib-version-parser.ts'
 
 vi.mock('node:fs', () => fs)
+vi.mock('node:module', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const original = await importOriginal<typeof import('node:module')>()
+	return {
+		...original,
+		findPackageJSON: vi.fn(),
+	}
+})
 
 describe('createLibVersionValidator', () => {
 	beforeAll(() => vol.fromNestedJSON({
@@ -27,11 +36,12 @@ describe('createLibVersionValidator', () => {
 	${'8.24.0'} | ${false}
 	${'9.0.0'}  | ${false}
 	`('returns false without nextcloud/vue in dependencies', ({ version, expected }) => {
+		vi.mocked(findPackageJSON).mockImplementation(() => {
+			throw new Error("Cannot find package '@nextcloud/vue' imported from /a/src/b.js", { cause: 'ERR_MODULE_NOT_FOUND' })
+		})
 		const fn = createLibVersionValidator({
 			cwd: '',
 			physicalFilename: '/a/src/b.js',
-		}, () => {
-			throw new Error('not found', { cause: 'ERR_MODULE_NOT_FOUND' })
 		})
 		expect(fn(version)).toBe(expected)
 	})
@@ -49,10 +59,11 @@ describe('createLibVersionValidator', () => {
 				src: {},
 			},
 		})
+		vi.mocked(findPackageJSON).mockReturnValue('/a/node_modules/@nextcloud/vue/package.json')
 		const fn = createLibVersionValidator({
 			cwd: '',
 			physicalFilename: '/a/src/b.js',
-		}, () => 'file:///a/node_modules/@nextcloud/vue/dist/index.js')
+		})
 		expect(fn('8.22.0')).toBe(true)
 		expect(fn('8.23.0')).toBe(true)
 		expect(fn('8.23.1')).toBe(true)
@@ -73,10 +84,11 @@ describe('createLibVersionValidator', () => {
 				src: {},
 			},
 		})
+		vi.mocked(findPackageJSON).mockReturnValue('/a/node_modules/@nextcloud/vue/package.json')
 		const fn = createLibVersionValidator({
 			cwd: '/a',
 			physicalFilename: 'src/b.js',
-		}, () => 'file:///a/node_modules/@nextcloud/vue/dist/index.js')
+		})
 
 		expect(fn('8.22.0')).toBe(true)
 		expect(fn('8.23.0')).toBe(true)

--- a/lib/plugins/nextcloud/utils/lib-version-parser.ts
+++ b/lib/plugins/nextcloud/utils/lib-version-parser.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { readFileSync } from 'node:fs'
-import { isAbsolute, join, resolve } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { findPackageJSON } from 'node:module'
+import { isAbsolute, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { gte } from 'semver'
 
 /**
@@ -19,31 +20,32 @@ const cachedMap = new Map<string, (version: string) => boolean>()
  * @param options Options
  * @param options.cwd The current working directory
  * @param options.physicalFilename The real filename where ESLint is linting currently
- * @param importResolve Optional custom import resolver function (for testing purposes)
  * @return Function validator, return a boolean whether current version satisfies minimal required for the rule
  */
-export function createLibVersionValidator({ cwd, physicalFilename }, importResolve = import.meta.resolve): ((version: string) => boolean) {
+export function createLibVersionValidator({ cwd, physicalFilename }: { cwd: string, physicalFilename: string }): ((version: string) => boolean) {
 	// Try to find package.json of the nextcloud-vue package
 	const sourceFile = isAbsolute(physicalFilename)
 		? resolve(physicalFilename)
 		: resolve(cwd, physicalFilename)
 
-	let packageJsonDir: string
+	let packageJsonPath: string | undefined
 	try {
-		const modulePath = fileURLToPath(importResolve('@nextcloud/vue', pathToFileURL(sourceFile)))
-		const idx = modulePath.lastIndexOf('/dist/')
-		packageJsonDir = modulePath.substring(0, idx)
+		packageJsonPath = findPackageJSON('@nextcloud/vue', pathToFileURL(sourceFile))
 	} catch {
+		packageJsonPath = undefined
+	}
+
+	if (!packageJsonPath) {
 		return () => false
 	}
 
-	if (!cachedMap.has(packageJsonDir)) {
-		const json = JSON.parse(readFileSync(join(packageJsonDir, 'package.json'), 'utf-8'))
+	if (!cachedMap.has(packageJsonPath)) {
+		const json = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
 		const libVersion = json.version
-		cachedMap.set(packageJsonDir, (version: string) => gte(libVersion, version))
+		cachedMap.set(packageJsonPath, (version: string) => gte(libVersion, version))
 	}
 
-	return cachedMap.get(packageJsonDir)!
+	return cachedMap.get(packageJsonPath)!
 }
 
 /**


### PR DESCRIPTION
- Fix: https://github.com/nextcloud-libraries/eslint-config/issues/1451
- Find `package.json` directly via `findPackageJSON` instead of `import.meta.resolve` and relying on `lastIndexOf('/dist/')`
- Also mock via `vi.mock` instead of additional param

Before | After
--- | ---
Supports only posix | Supports both posix and win32
Depends on the current `@nextcloud/vue` directory structure | Works regardless of the `@nextcloud/vue` directory structure

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
