### PR TITLE
fix: increase min. Node version to 22.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": "^22.13 || ^24 || >=26"
+        "node": "^22.14 || ^24 || >=26"
       },
       "peerDependencies": {
         "eslint": ">=10"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint": ">=10"
   },
   "engines": {
-    "node": "^22.13 || ^24 || >=26"
+    "node": "^22.14 || ^24 || >=26"
   },
   "devEngines": {
     "packageManager": [


### PR DESCRIPTION
- ref https://github.com/nextcloud-libraries/eslint-config/pull/1454

Regression from when we used `node:module` `findPackageJSON`. This method was added just with 22.14+.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
