### PR TITLE
fix: add deprecation rule for rest of migrated props

### DIFF
--- a/lib/plugins/nextcloud/rules/no-deprecated-library-props.test.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-props.test.ts
@@ -94,6 +94,10 @@ describe('no-deprecated-library-props', () => {
 					code: '<template><NcButton :variant="isPrimary ? \'primary\' : \'tertiary\'">Hello</NcButton></template>',
 					filename: '/a/src/component.vue',
 				},
+				{
+					code: '<template><NcRadioGroup hide-label :value="v" /></template>',
+					filename: '/a/src/component.vue',
+				},
 			],
 			invalid: [
 				{
@@ -340,6 +344,28 @@ describe('no-deprecated-library-props', () => {
 					errors: [{ messageId: 'useModelValueInsteadValue' }],
 					output: '<template><NcTextField v-model="input" /></template>',
 				},
+				{
+					code: '<template><NcRadioGroup label-hidden :value="v" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useHideLabelInstead' }],
+					output: '<template><NcRadioGroup hide-label :value="v" /></template>',
+				},
+				{
+					code: '<template><NcRadioGroup :label-hidden="cond" :value="v" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useHideLabelInstead' }],
+					output: '<template><NcRadioGroup :hide-label="cond" :value="v" /></template>',
+				},
+				{
+					code: '<template><NcCheckboxRadioSwitch button-variant>Option</NcCheckboxRadioSwitch></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNcRadioGroupInstead' }],
+				},
+				{
+					code: '<template><NcCheckboxRadioSwitch button-variant-grouped="continuous">Option</NcCheckboxRadioSwitch></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNcRadioGroupInstead' }],
+				},
 			],
 		})
 	})
@@ -365,6 +391,10 @@ describe('no-deprecated-library-props', () => {
 				// Same prop name on a plain element must not be flagged by this rule
 				{
 					code: '<template><input formatter="x" /></template>',
+					filename: '/a/src/component.vue',
+				},
+				{
+					code: '<template><NcRadioGroup hideLabel :value="v" /></template>',
 					filename: '/a/src/component.vue',
 				},
 			],
@@ -416,6 +446,57 @@ describe('no-deprecated-library-props', () => {
 					filename: '/a/src/component.vue',
 					errors: [{ messageId: 'useArrowEndInstead' }],
 					output: '<template><NcTextField trailingButtonIcon="arrowEnd" /></template>',
+				},
+				// The fixer emits kebab-case props; `vue/attribute-hyphenation` will change it on second pass
+				{
+					code: '<template><NcTextField :value="input" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useModelValueInsteadValue' }],
+					output: '<template><NcTextField :model-value="input" /></template>',
+				},
+				{
+					code: '<template><NcRadioGroup labelHidden :value="v" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useHideLabelInstead' }],
+					output: '<template><NcRadioGroup hide-label :value="v" /></template>',
+				},
+				{
+					code: '<template><NcRadioGroup :labelHidden="cond" :value="v" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useHideLabelInstead' }],
+					output: '<template><NcRadioGroup :hide-label="cond" :value="v" /></template>',
+				},
+				{
+					code: '<template><NcCheckboxRadioSwitch buttonVariant>Option</NcCheckboxRadioSwitch></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNcRadioGroupInstead' }],
+				},
+				{
+					code: '<template><NcCheckboxRadioSwitch :buttonVariantGrouped="grouped">Option</NcCheckboxRadioSwitch></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useNcRadioGroupInstead' }],
+				},
+				{
+					code: '<template><NcAutoCompleteResult title="Alice" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useLabelInstead' }],
+					output: '<template><NcAutoCompleteResult label="Alice" /></template>',
+				},
+				{
+					code: '<template><NcMentionBubble :title="name" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'useLabelInstead' }],
+					output: '<template><NcMentionBubble :label="name" /></template>',
+				},
+				{
+					code: '<template><NcAppSettingsDialog legacy :open="open" name="Settings" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'removeLegacy' }],
+				},
+				{
+					code: '<template><NcAppSettingsDialog :legacy="true" :open="open" name="Settings" /></template>',
+					filename: '/a/src/component.vue',
+					errors: [{ messageId: 'removeLegacy' }],
 				},
 			],
 		})

--- a/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
@@ -75,6 +75,10 @@ export default {
 			useCloseButtonOutsideInstead: 'Using `close-button-contained` is deprecated - use `close-button-outside` instead',
 			useModelValueInsteadChecked: 'Using `checked` is deprecated - use `model-value` or `v-model` instead',
 			useModelValueInsteadValue: 'Using `value` is deprecated - use `model-value` or `v-model` instead',
+			useHideLabelInstead: 'Using `label-hidden` is deprecated - use `hide-label` instead',
+			useNcRadioGroupInstead: 'Using `button-variant` / `button-variant-grouped` is deprecated - use the `NcRadioGroup` component instead',
+			useLabelInstead: 'Using `title` is deprecated - use `label` instead',
+			removeLegacy: 'Using `legacy` is deprecated - the legacy design will be removed, migrate to the new design',
 		},
 	},
 
@@ -92,6 +96,10 @@ export default {
 		const isNcSelectUsersValid = versionSatisfies('8.25.0') // #6791
 		const isNcTextFieldArrowEndValid = versionSatisfies('8.28.0') // #7002
 		const isCloseButtonOutsideValid = versionSatisfies('8.32.0') // #7553
+		const isTitleLabelValid = versionSatisfies('8.6.2') // #5215
+		const isNcRadioGroupValid = versionSatisfies('8.31.0') // #7492
+		const isHideLabelValid = versionSatisfies('8.34.0') // #7772
+		const isAppSettingsLegacyValid = versionSatisfies('8.34.0') // #7802
 
 		const legacyTypes = [
 			'primary',
@@ -530,6 +538,91 @@ export default {
 							}
 						}
 					},
+				})
+			},
+
+			labelHidden: function(node) {
+				if (node.parent.parent.name !== 'ncradiogroup') {
+					return
+				}
+
+				if (!isHideLabelValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
+				context.report({
+					node,
+					messageId: 'useHideLabelInstead',
+					fix: (fixer) => {
+						if (node.key.type === 'VIdentifier') {
+							return fixer.replaceTextRange(node.key.range, 'hide-label')
+						} else if (node.key.type === 'VDirectiveKey') {
+							return fixer.replaceTextRange(node.key.argument.range, 'hide-label')
+						}
+					},
+				})
+			},
+
+			buttonVariant: function(node) {
+				if (node.parent.parent.name !== 'nccheckboxradioswitch') {
+					return
+				}
+
+				if (!isNcRadioGroupValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
+				context.report({
+					node,
+					messageId: 'useNcRadioGroupInstead',
+				})
+			},
+
+			// Same correction as `button-variant`
+			buttonVariantGrouped(node) {
+				handlers.buttonVariant(node)
+			},
+
+			title: function(node) {
+				if (![
+					'ncautocompleteresult',
+					'ncmentionbubble',
+				].includes(node.parent.parent.name)) {
+					return
+				}
+
+				if (!isTitleLabelValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
+				context.report({
+					node,
+					messageId: 'useLabelInstead',
+					fix: (fixer) => {
+						if (node.key.type === 'VIdentifier') {
+							return fixer.replaceTextRange(node.key.range, 'label')
+						} else if (node.key.type === 'VDirectiveKey') {
+							return fixer.replaceTextRange(node.key.argument.range, 'label')
+						}
+					},
+				})
+			},
+
+			legacy: function(node) {
+				if (node.parent.parent.name !== 'ncappsettingsdialog') {
+					return
+				}
+				if (!isAppSettingsLegacyValid) {
+					context.report({ node, messageId: 'outdatedVueLibrary' })
+					return
+				}
+
+				context.report({
+					node,
+					messageId: 'removeLegacy',
 				})
 			},
 


### PR DESCRIPTION
Ref #1001 
Cover the rest of props:
```
'Using `label-hidden` is deprecated - use `hide-label` instead',
'Using `button-variant` / `button-variant-grouped` is deprecated - use the `NcRadioGroup` component instead',
'Using `title` is deprecated - use `label` instead',
'Using `legacy` is deprecated - the legacy design will be removed, migrate to the new design',
```


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
- [x] Assisted-by: ClaudeCode:claude-opus-4-8
