### PR TITLE
fix: support multiple threshold versions for deprecated rules

### DIFF
--- a/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
+++ b/lib/plugins/nextcloud/rules/no-deprecated-library-props.ts
@@ -85,21 +85,21 @@ export default {
 	create(context) {
 		const versionSatisfies = createLibVersionValidator(context)
 		const isVue3Valid = versionSatisfies('9.0.0') // #6651
-		const isAriaHiddenValid = versionSatisfies('8.2.0') // #4835
-		const isModelValueValid = versionSatisfies('8.20.0') // #6172
-		const isDisableSwipeValid = versionSatisfies('8.23.0') // #6452
-		const isVariantTypeValid = versionSatisfies('8.24.0') // #6472
-		const isDefaultBooleanFalseValid = versionSatisfies('8.24.0') // #6656
-		const isDateTimePickerFormatValid = versionSatisfies('8.25.0') // #6738
-		const isNcSelectKeepOpenValid = versionSatisfies('8.25.0') // #6791
-		const isNcPopoverNoFocusTrapValid = versionSatisfies('8.26.0') // #6808
-		const isNcSelectUsersValid = versionSatisfies('8.25.0') // #6791
-		const isNcTextFieldArrowEndValid = versionSatisfies('8.28.0') // #7002
-		const isCloseButtonOutsideValid = versionSatisfies('8.32.0') // #7553
-		const isTitleLabelValid = versionSatisfies('8.6.2') // #5215
-		const isNcRadioGroupValid = versionSatisfies('8.31.0') // #7492
-		const isHideLabelValid = versionSatisfies('8.34.0') // #7772
-		const isAppSettingsLegacyValid = versionSatisfies('8.34.0') // #7802
+		const isAriaHiddenValid = versionSatisfies('8.2.0') // #4835 (stable8)
+		const isModelValueValid = versionSatisfies('8.20.0') // #6172 (stable8)
+		const isDisableSwipeValid = versionSatisfies('8.23.0', '9.0.0') // #6452 (stable8) / #6509 (main)
+		const isVariantTypeValid = versionSatisfies('8.24.0', '9.0.0') // #6472 (stable8) / #6595 (main)
+		const isDefaultBooleanFalseValid = versionSatisfies('8.24.0', '9.0.0') // #6656 (stable8) / #6653 (main)
+		const isDateTimePickerFormatValid = versionSatisfies('8.25.0', '9.0.0') // #6738 (stable8) / #6651 (main)
+		const isNcSelectKeepOpenValid = versionSatisfies('8.25.0', '9.0.0') // #6791 (stable8) / #6732 (main)
+		const isNcPopoverNoFocusTrapValid = versionSatisfies('8.26.0', '9.0.0') // #6808 (stable8) / #6807 (main)
+		const isNcSelectUsersValid = versionSatisfies('8.25.0', '9.0.0') // #6791 (stable8) / #6732 (main)
+		const isNcTextFieldArrowEndValid = versionSatisfies('8.28.0', '9.0.0') // #7002 (stable8) / #6993 (main)
+		const isCloseButtonOutsideValid = versionSatisfies('8.32.0', '9.0.0') // #7553 (stable8) / #6719 (main)
+		const isTitleLabelValid = versionSatisfies('8.6.2', '9.0.0') // #5215 (stable8)
+		const isNcRadioGroupValid = versionSatisfies('8.31.0', '9.0.0') // #7492 (stable8) / #7490 (main)
+		const isHideLabelValid = versionSatisfies('8.34.0', '9.2.0') // #7772 (stable8) / #7771 (main)
+		const isAppSettingsLegacyValid = versionSatisfies('8.34.0', '9.2.0') // #7802 (stable8) / #7797 (main)
 
 		const legacyTypes = [
 			'primary',

--- a/lib/plugins/nextcloud/utils/lib-version-parser.test.ts
+++ b/lib/plugins/nextcloud/utils/lib-version-parser.test.ts
@@ -96,4 +96,40 @@ describe('createLibVersionValidator', () => {
 		expect(fn('8.24.0')).toBe(false)
 		expect(fn('9.0.0')).toBe(false)
 	})
+
+	it('matches the threshold for the installed major (9.x)', () => {
+		vol.fromNestedJSON({
+			'/b': {
+				node_modules: { '@nextcloud': { vue: { 'package.json': '{"version": "9.1.0"}' } } },
+				src: {},
+			},
+		})
+		vi.mocked(findPackageJSON).mockReturnValue('/b/node_modules/@nextcloud/vue/package.json')
+		const fn = createLibVersionValidator({ cwd: '', physicalFilename: '/b/src/b.js' })
+
+		// 9.1.0 is compared against the 9.x threshold, not the backported 8.x one
+		expect(fn('8.34.0', '9.2.0')).toBe(false) // deprecated on main only from 9.2.0
+		expect(fn('8.34.0', '9.0.0')).toBe(true)
+		expect(fn('9.1.0')).toBe(true)
+		expect(fn('9.2.0')).toBe(false)
+		// a lone 8.x threshold still applies to a 9.x install (feature removed in v9)
+		expect(fn('8.24.0')).toBe(true)
+		// a threshold from a newer major than installed is never satisfied
+		expect(fn('10.0.0')).toBe(false)
+	})
+
+	it('matches the threshold for the installed major (8.x)', () => {
+		vol.fromNestedJSON({
+			'/c': {
+				node_modules: { '@nextcloud': { vue: { 'package.json': '{"version": "8.35.0"}' } } },
+				src: {},
+			},
+		})
+		vi.mocked(findPackageJSON).mockReturnValue('/c/node_modules/@nextcloud/vue/package.json')
+		const fn = createLibVersionValidator({ cwd: '', physicalFilename: '/c/src/b.js' })
+
+		// 8.35.0 is compared against the 8.x threshold, ignoring the 9.x one
+		expect(fn('8.34.0', '9.2.0')).toBe(true)
+		expect(fn('8.36.0', '9.0.0')).toBe(false)
+	})
 })

--- a/lib/plugins/nextcloud/utils/lib-version-parser.ts
+++ b/lib/plugins/nextcloud/utils/lib-version-parser.ts
@@ -6,23 +6,30 @@ import { readFileSync } from 'node:fs'
 import { findPackageJSON } from 'node:module'
 import { isAbsolute, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { gte } from 'semver'
+import { compare, gte, major } from 'semver'
 
 /**
  * Cached map of paths: Reco <path_to_package.json, validator>
  */
-const cachedMap = new Map<string, (version: string) => boolean>()
+const cachedMap = new Map<string, (...versions: string[]) => boolean>()
 
 /**
- * Create a callback that takes a version number and checks if the version
- * is valid compared to configured version / detected version.
+ * Create a callback that checks whether the installed library version satisfies
+ * a minimal required version.
+ *
+ * The validator accepts one threshold per major release line, e.g.
+ * `versionSatisfies('8.34.0', '9.2.0')` for a deprecation that was backported to
+ * stable8 in 8.34.0 and landed on main in 9.2.0. The installed version is
+ * compared against the threshold matching its own major (falling back to the
+ * highest threshold from an earlier major), so a 9.0.0 installation is not flagged by
+ * a deprecation that only exists from 9.2.0 onwards.
  *
  * @param options Options
  * @param options.cwd The current working directory
  * @param options.physicalFilename The real filename where ESLint is linting currently
  * @return Function validator, return a boolean whether current version satisfies minimal required for the rule
  */
-export function createLibVersionValidator({ cwd, physicalFilename }: { cwd: string, physicalFilename: string }): ((version: string) => boolean) {
+export function createLibVersionValidator({ cwd, physicalFilename }: { cwd: string, physicalFilename: string }): ((...versions: string[]) => boolean) {
 	// Try to find package.json of the nextcloud-vue package
 	const sourceFile = isAbsolute(physicalFilename)
 		? resolve(physicalFilename)
@@ -42,7 +49,14 @@ export function createLibVersionValidator({ cwd, physicalFilename }: { cwd: stri
 	if (!cachedMap.has(packageJsonPath)) {
 		const json = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
 		const libVersion = json.version
-		cachedMap.set(packageJsonPath, (version: string) => gte(libVersion, version))
+		cachedMap.set(packageJsonPath, (...versions: string[]) => {
+			// Pick the threshold for the installed major (or the highest from an
+			// earlier major), then check the installed version against it.
+			const [threshold] = versions
+				.filter((version) => major(version) <= major(libVersion))
+				.sort((a, b) => compare(b, a))
+			return threshold !== undefined && gte(libVersion, threshold)
+		})
 	}
 
 	return cachedMap.get(packageJsonPath)!


### PR DESCRIPTION
- e.g. rule for NcAppSettingsDialog was introduced in 9.2.0 and backported to 8.34.0 - it won't be valid in 9.0.0 and 9.1.0
- rule internal docs adjusted with PR numbers for original v9 / backport v8

After:
nextcloud/vue v9.1.0:
<img width="979" height="161" alt="image" src="https://github.com/user-attachments/assets/d2221604-6fe7-47bd-bbb2-fdf9b9666342" />

nextcloud/vue v9.9.0:
<img width="915" height="154" alt="image" src="https://github.com/user-attachments/assets/ef933d78-8e30-4ad4-a411-bf88393d28f5" />

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
- [x] Assisted-by: ClaudeCode:claude-opus-4-8
