### PR TITLE
ci: update dependabot-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -26,6 +26,13 @@ jobs:
   auto-approve-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
+    env:
+      # env variable for maintainers: 'true' allows to auto-merge 1.0.2 -> 2.0.0
+      ALLOW_MAJOR: false
+      # env variable for maintainers: 'true' allows to auto-merge 1.0.2 -> 1.1.0
+      ALLOW_MINOR: true
+      # env variable for maintainers: RegExp string to ignore some dependencies from auto-approve and auto-merge
+      IGNORE_PATTERN: ''
     permissions:
       # for auto-approve step to work
       pull-requests: write


### PR DESCRIPTION
Automated update of the dependabot-approve-merge.yml workflow from https://github.com/nextcloud-libraries/.github triggered by susnux